### PR TITLE
fix(ci): fix artifact upload and updater metadata generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,7 @@ jobs:
             src-tauri/target/release/bundle/dmg/*.dmg
             src-tauri/target/*/release/bundle/dmg/*.dmg
             src-tauri/target/release/bundle/msi/*.msi
+            src-tauri/target/release/bundle/updater/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -230,28 +231,30 @@ jobs:
 
           PLATFORMS="{}"
 
-          SIG=$(get_sig "darwin-aarch64.*\.sig")
-          URL=$(get_url "aarch64.dmg")
-          if [ -n "$SIG" ]; then
+          SIG=$(get_sig "aarch64.*\.sig")
+          URL=$(get_url "aarch64.*\.tar\.gz")
+          if [ -z "$URL" ] || [ "$URL" == "null" ]; then URL=$(get_url "aarch64.*\.dmg"); fi
+          if [ -n "$SIG" ] && [ -n "$URL" ] && [ "$URL" != "null" ]; then
             PLATFORMS=$(echo $PLATFORMS | jq ". + {\"darwin-aarch64\": {\"signature\": \"$SIG\", \"url\": \"$URL\"}}")
           fi
- 
-          SIG=$(get_sig "darwin-x86_64.*\.sig")
-          URL=$(get_url "x64.dmg")
-          if [ -n "$SIG" ]; then
+  
+          SIG=$(get_sig "(x64|x86_64).*\.sig")
+          URL=$(get_url "x64.*\.tar\.gz")
+          if [ -z "$URL" ] || [ "$URL" == "null" ]; then URL=$(get_url "x64.*\.dmg"); fi
+          if [ -n "$SIG" ] && [ -n "$URL" ] && [ "$URL" != "null" ]; then
             PLATFORMS=$(echo $PLATFORMS | jq ". + {\"darwin-x86_64\": {\"signature\": \"$SIG\", \"url\": \"$URL\"}}")
           fi
- 
-          SIG=$(get_sig "windows-x86_64.*\.sig")
-          URL=$(get_url "\.msi")
-          if [ -z "$URL" ] || [ "$URL" == "null" ]; then URL=$(get_url "setup.exe"); fi
-          if [ -n "$SIG" ]; then
+  
+          SIG=$(get_sig "x64.*\.msi\.sig")
+          URL=$(get_url "x64.*\.msi")
+          if [ -z "$URL" ] || [ "$URL" == "null" ]; then URL=$(get_url "setup\.exe"); fi
+          if [ -n "$SIG" ] && [ -n "$URL" ] && [ "$URL" != "null" ]; then
             PLATFORMS=$(echo $PLATFORMS | jq ". + {\"windows-x86_64\": {\"signature\": \"$SIG\", \"url\": \"$URL\"}}")
           fi
- 
-          SIG=$(get_sig "linux-x86_64.*\.sig")
+  
+          SIG=$(get_sig "AppImage\.sig")
           URL=$(get_url "AppImage")
-          if [ -n "$SIG" ]; then
+          if [ -n "$SIG" ] && [ -n "$URL" ] && [ "$URL" != "null" ]; then
             PLATFORMS=$(echo $PLATFORMS | jq ". + {\"linux-x86_64\": {\"signature\": \"$SIG\", \"url\": \"$URL\"}}")
           fi
 


### PR DESCRIPTION
- Add updater bundles and signatures to the whitelisted assets in release workflow.
- Update publish-updater job with robust regex patterns to correctly detect Tauri v2 assets.
- Improve fallback logic for detecting platform URLs (preferring .tar.gz over .dmg).

This ensures that latest.json is correctly generated and uploaded for Tauri auto-updates.