### PR TITLE
fix(onboarding): smooth setup and skill import rough edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ You can leverage local AI models (Ollama), hosted AI services (Claude), local co
 
 **productOS** is distributed as a native Node.js application — no Rust, no Electron, no platform-specific binaries required.
 
-### Option 1: One-shot via npx (no install needed)
+### 📋 Prerequisites
+
+- **Node.js (v18+)**: Required to run the core application.
+- **Ollama** (Optional): For running local AI models.
+- **Claude Code CLI** (Optional): For advanced coding assistance.
+- **Gemini CLI** (Optional): For Google's Gemini models.
+
+### Option 1: One-shot via npx (Recommended)
 
 ```bash
 npx productos
@@ -33,13 +40,7 @@ npm install -g productos
 productos
 ```
 
-> **Requires Node.js v18 or later.** Download from [nodejs.org](https://nodejs.org).
-
-### Option 3: Download a release
-
-Pre-built release archives are available on the [GitHub Releases page](https://github.com/AIResearchFactory/productOS/releases). This is the recommended path for product managers who should not need to clone the repo or run developer setup commands.
-
-### Option 4: Build from source (For Developers)
+### Option 3: Build from source (For Developers)
 
 If you want to contribute or run from source:
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,7 @@ productos
 
 > **Requires Node.js v18 or later.** Download from [nodejs.org](https://nodejs.org).
 
-### Option 3: Download a release
-
-Pre-built release archives are available on the [GitHub Releases page](https://github.com/AIResearchFactory/productOS/releases). This is the recommended path for product managers who should not need to clone the repo or run developer setup commands.
-
-### Option 4: Build from source (For Developers)
+### Option 3: Build from source (For Developers)
 
 If you want to contribute or run from source:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ productos
 
 ### Option 3: Download a release
 
-Pre-built release archives are available on the [GitHub Releases page](https://github.com/AIResearchFactory/productOS/releases).
+Pre-built release archives are available on the [GitHub Releases page](https://github.com/AIResearchFactory/productOS/releases). This is the recommended path for product managers who should not need to clone the repo or run developer setup commands.
 
 ### Option 4: Build from source (For Developers)
 
@@ -49,6 +49,8 @@ cd productOS
 npm install
 npm run dev
 ```
+
+> Run `npm install` before any `npm run ...` or `npx vite` command. The source clone does not include `node_modules`, so Vite plugins such as `@vitejs/plugin-react` and `vite-plugin-pwa` are unavailable until dependencies are installed.
 
 
 ---
@@ -79,8 +81,9 @@ Open **Settings → Models** and pick your preferred provider:
 | **Claude Code CLI** | Run `claude login` |
 | **OpenAI CLI / API** | Add your OpenAI API key in Settings |
 | **Ollama** | Start Ollama locally and pull a model: `ollama pull llama3` |
+| **OpenCode** | Optional custom CLI: install separately with `npm install -g opencode-ai`, then add it under Settings → Models → Custom Model CLIs |
 
-Once a provider is ready, start chatting in any project workspace.
+Once a provider is ready, start chatting in any project workspace. If chat says a provider is not ready, verify that the same provider is selected, installed/authenticated, and configured in **Settings → Models**.
 
 ### 3. Production build (from source)
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ You can leverage local AI models (Ollama), hosted AI services (Claude), local co
 
 ### 📋 Prerequisites
 
-- **Node.js (v18+)**: Required to run the core application.
-- **Ollama** (Optional): For running local AI models.
-- **Claude Code CLI** (Optional): For advanced coding assistance.
-- **Gemini CLI** (Optional): For Google's Gemini models.
+- **Node.js (v18+)**: Required to run the core application. Download from [nodejs.org](https://nodejs.org).
+- At least one of the following AI tools installed:
+  - **Ollama** (Optional): For running local AI models. Download from [ollama.com](https://ollama.com).
+  - **Claude Code CLI** (Optional): For advanced coding assistance. Download from [claude.com/code](https://claude.com/code).
+  - **Gemini CLI** (Optional): For Google's Gemini models. Download from [ai.google.dev/gemini-api/docs/cli](https://ai.google.dev/gemini-api/docs/cli).
+  - **Custom Model CLI** (Optional): For running custom AI models.
 
 ### Option 1: One-shot via npx (Recommended)
 

--- a/docs/03-installation.md
+++ b/docs/03-installation.md
@@ -45,32 +45,9 @@ npm install -g productos
 productos
 ```
 
-### Alternative: Download Pre-packaged Release
-
-If you are a product manager or non-developer, start here instead of cloning the repo. Visit the [productOS releases page](https://github.com/AIResearchFactory/productOS/releases) and download the latest version for your operating system:
-
-- **macOS**: `productOS_macos.zip`
-- **Windows**: `productOS_windows.zip`
-- **Linux**: `productOS_linux.tar.gz`
-
-#### macOS
-1. Unzip the downloaded file
-2. Move **productOS** to your Applications folder
-3. Launch **productOS**
-
-#### Windows
-1. Unzip the downloaded file
-2. Run `productOS.exe`
-
-#### Linux
-1. Extract the archive
-2. Run the `productOS` executable
-
----
-
 ### Build from Source
 
-This path is for contributors and developers. Non-developer users should use the pre-packaged release above so they do not need to manage source dependencies manually.
+This path is for contributors and developers.
 
 For contributors running from a Git clone:
 
@@ -276,21 +253,10 @@ To verify your installation is working correctly:
 
 ## Troubleshooting
 
-### Installation Issues
-
-**Problem**: "App can't be opened" on macOS
-**Solution**: Go to System Preferences → Security & Privacy → Click "Open Anyway"
-
-**Problem**: Windows SmartScreen warning
-**Solution**: Click "More info" → "Run anyway"
-
-**Problem**: Linux permission denied
-**Solution**: Make the AppImage executable: `chmod +x ai-researcher*.AppImage`
-
 ### Configuration Issues
 
 **Problem**: `npx vite` or Vite cannot resolve `@vitejs/plugin-react` / `vite-plugin-pwa` from a source clone
-**Solution**: Run `npm install` in the repository first. The clone intentionally does not include dependencies.
+
 
 **Problem**: Chat says the selected AI provider needs setup, but Settings looks correct
 **Solution**: Confirm that the **active provider** in Settings → Models is the same provider you authenticated. For CLI providers, also confirm the CLI is available in your terminal PATH and logged in (`claude login`, Gemini auth, Codex/OpenAI login, etc.). Then refresh provider detection or restart productOS.

--- a/docs/03-installation.md
+++ b/docs/03-installation.md
@@ -38,16 +38,16 @@ The easiest way to install and run **productOS** is via npm. This works on macOS
 
 ```bash
 # Launch directly with npx
-npx @productos/cli
+npx productos
 
 # Or install globally
-npm install -g @productos/cli
+npm install -g productos
 productos
 ```
 
 ### Alternative: Download Pre-packaged Release
 
-If you prefer a standalone application, you can visit the [productOS releases page](https://github.com/AIResearchFactory/ai-researcher/releases) and download the latest version for your operating system:
+If you are a product manager or non-developer, start here instead of cloning the repo. Visit the [productOS releases page](https://github.com/AIResearchFactory/productOS/releases) and download the latest version for your operating system:
 
 - **macOS**: `productOS_macos.zip`
 - **Windows**: `productOS_windows.zip`
@@ -65,6 +65,23 @@ If you prefer a standalone application, you can visit the [productOS releases pa
 #### Linux
 1. Extract the archive
 2. Run the `productOS` executable
+
+---
+
+### Build from Source
+
+This path is for contributors and developers. Non-developer users should use the pre-packaged release above so they do not need to manage source dependencies manually.
+
+For contributors running from a Git clone:
+
+```bash
+git clone https://github.com/AIResearchFactory/productOS.git
+cd productOS
+npm install
+npm run dev
+```
+
+Run `npm install` before `npm run dev`, `npm run build`, or `npx vite`. A fresh clone does not include `node_modules`, so running Vite before installing dependencies can produce unresolved import errors for packages such as `@vitejs/plugin-react` and `vite-plugin-pwa`.
 
 ---
 
@@ -151,6 +168,21 @@ Visit [Anthropic's documentation](https://docs.anthropic.com) for installation i
 
 **Installation**:
 Follow Google's official Gemini CLI installation guide.
+
+### OpenCode (Optional Custom CLI)
+
+**What it is**: A third-party AI coding CLI that can be wired into productOS as a custom model CLI.
+
+**Why use it**: Useful if your team already uses OpenCode and wants it available from productOS workflows.
+
+**Installation**:
+
+```bash
+npm install -g opencode-ai
+opencode --help
+```
+
+Then open **Settings → Models → Custom Model CLIs** and add an entry that runs the `opencode` command. OpenCode is not bundled with the productOS source clone or npm package.
 
 ### Important Notes
 
@@ -246,32 +278,41 @@ To verify your installation is working correctly:
 
 ### Installation Issues
 
-**Problem**: "App can't be opened" on macOS  
+**Problem**: "App can't be opened" on macOS
 **Solution**: Go to System Preferences → Security & Privacy → Click "Open Anyway"
 
-**Problem**: Windows SmartScreen warning  
+**Problem**: Windows SmartScreen warning
 **Solution**: Click "More info" → "Run anyway"
 
-**Problem**: Linux permission denied  
+**Problem**: Linux permission denied
 **Solution**: Make the AppImage executable: `chmod +x ai-researcher*.AppImage`
 
 ### Configuration Issues
 
-**Problem**: Can't find data directory  
+**Problem**: `npx vite` or Vite cannot resolve `@vitejs/plugin-react` / `vite-plugin-pwa` from a source clone
+**Solution**: Run `npm install` in the repository first. The clone intentionally does not include dependencies.
+
+**Problem**: Chat says the selected AI provider needs setup, but Settings looks correct
+**Solution**: Confirm that the **active provider** in Settings → Models is the same provider you authenticated. For CLI providers, also confirm the CLI is available in your terminal PATH and logged in (`claude login`, Gemini auth, Codex/OpenAI login, etc.). Then refresh provider detection or restart productOS.
+
+**Problem**: Skill import hangs at an agent-selection prompt
+**Solution**: Use a non-interactive command such as `npx skills add https://github.com/anthropics/skills --skill frontend-design --yes --agent openclaw --copy`. The in-app importer now adds these flags automatically when they are omitted.
+
+**Problem**: Can't find data directory
 **Solution**: 
 1. Open Settings
 2. Click "Change Data Directory"
 3. Select or create a new folder
 4. Restart productOS
 
-**Problem**: API key not working  
+**Problem**: API key not working
 **Solution**:
 1. Verify the key is correct (check your AI provider's dashboard)
 2. Ensure you have API credits/quota available
 3. Try removing and re-adding the key
 4. Check your internet connection
 
-**Problem**: Ollama not detected  
+**Problem**: Ollama not detected
 **Solution**:
 1. Verify Ollama is installed: `ollama --version`
 2. Start Ollama service: `ollama serve`
@@ -279,25 +320,25 @@ To verify your installation is working correctly:
 
 ### Password Issues
 
-**Problem**: Forgot password  
+**Problem**: Forgot password
 **Solution**: Unfortunately, encrypted secrets cannot be recovered without the password. You'll need to:
 1. Delete the `.secrets.encrypted` file from your data directory
 2. Re-enter your API keys
 3. Set a new password
 
-**Problem**: Password prompt every time  
+**Problem**: Password prompt every time
 **Solution**: This is by design for security. Your password unlocks your encrypted API keys. There's no way to disable this while maintaining encryption.
 
 ### Performance Issues
 
-**Problem**: App is slow  
+**Problem**: App is slow
 **Solution**:
 1. Check if you have many large files in projects
 2. Close unused projects
 3. Ensure you have enough RAM available
 4. Try restarting the application
 
-**Problem**: AI responses are slow  
+**Problem**: AI responses are slow
 **Solution**:
 1. This is usually due to the AI provider's response time
 2. Try a different model (smaller models are faster)

--- a/docs/03-installation.md
+++ b/docs/03-installation.md
@@ -45,27 +45,6 @@ npm install -g productos
 productos
 ```
 
-### Alternative: Download Pre-packaged Release
-
-If you are a product manager or non-developer, start here instead of cloning the repo. Visit the [productOS releases page](https://github.com/AIResearchFactory/productOS/releases) and download the latest version for your operating system:
-
-- **macOS**: `productOS_macos.zip`
-- **Windows**: `productOS_windows.zip`
-- **Linux**: `productOS_linux.tar.gz`
-
-#### macOS
-1. Unzip the downloaded file
-2. Move **productOS** to your Applications folder
-3. Launch **productOS**
-
-#### Windows
-1. Unzip the downloaded file
-2. Run `productOS.exe`
-
-#### Linux
-1. Extract the archive
-2. Run the `productOS` executable
-
 ---
 
 ### Build from Source
@@ -275,17 +254,6 @@ To verify your installation is working correctly:
 ---
 
 ## Troubleshooting
-
-### Installation Issues
-
-**Problem**: "App can't be opened" on macOS
-**Solution**: Go to System Preferences → Security & Privacy → Click "Open Anyway"
-
-**Problem**: Windows SmartScreen warning
-**Solution**: Click "More info" → "Run anyway"
-
-**Problem**: Linux permission denied
-**Solution**: Make the AppImage executable: `chmod +x ai-researcher*.AppImage`
 
 ### Configuration Issues
 

--- a/e2e/deep_check.spec.ts
+++ b/e2e/deep_check.spec.ts
@@ -130,7 +130,7 @@ test.describe('Deep Feature Check', () => {
 
         const pageText = await page.locator('body').innerText();
         if (pageText.includes('Settings → Models')) {
-            expect(pageText).toMatch(/needs setup before it can answer|isn't available on this machine/i);
+            expect(pageText).toMatch(/needs setup before it can answer|isn't available on this machine|is not ready, so chat cannot run yet/i);
             return;
         }
 

--- a/node-backend/lib/orchestrator.mjs
+++ b/node-backend/lib/orchestrator.mjs
@@ -9,6 +9,33 @@ import * as ArtifactService from './artifacts.mjs';
 import { ChannelService } from './channels.mjs';
 import path from 'node:path';
 
+function providerSetupGuidance(providerId, settings = {}) {
+  const labels = {
+    hostedApi: 'Hosted API',
+    ollama: 'Ollama',
+    claudeCode: 'Claude Code CLI',
+    geminiCli: 'Gemini CLI',
+    openAiCli: 'OpenAI CLI',
+    liteLlm: 'LiteLLM',
+  };
+  const label = labels[providerId] || providerId;
+  const selected = Array.isArray(settings.selectedProviders) ? settings.selectedProviders : [];
+  const selectedNote = selected.length > 0 && !selected.includes(providerId)
+    ? `\n\nNote: ${label} is active, but your selected providers are: ${selected.map((id) => labels[id] || id).join(', ')}.`
+    : '';
+
+  const checks = {
+    hostedApi: 'Add a hosted API key and model in Settings → Models → Hosted API, or switch to a detected CLI provider.',
+    ollama: 'Start Ollama locally, pull a model (for example `ollama pull llama3`), then choose it in Settings → Models.',
+    claudeCode: 'Install Claude Code and run `claude login`, then refresh Settings → Models.',
+    geminiCli: 'Install Gemini CLI and authenticate it, or add a Gemini API key in Settings → Models.',
+    openAiCli: 'Install Codex/OpenAI CLI and sign in, or add an OpenAI API key in Settings → Models.',
+    liteLlm: 'Start your LiteLLM proxy and verify the base URL/API key in Settings → Models.',
+  };
+
+  return `The selected AI provider (${label}) is not ready, so chat cannot run yet.${selectedNote}\n\n${checks[providerId] || 'Open Settings → Models, verify this provider is installed/authenticated, or switch to another detected provider.'}`;
+}
+
 export class AgentOrchestrator {
   constructor(aiService) {
     this.aiService = aiService;
@@ -44,7 +71,7 @@ export class AgentOrchestrator {
     if (!isAvailable) {
       this.emit('trace-log', `WARN: Provider ${activeProvider} is not available or authenticated.`);
       return {
-        content: `The selected AI provider (${activeProvider}) needs setup before it can answer. Please check your API keys or local server status in Settings → Models.`,
+        content: providerSetupGuidance(activeProvider, settings),
         metadata: { model_used: 'none', tokens_in: 0, tokens_out: 0 }
       };
     }
@@ -71,7 +98,7 @@ export class AgentOrchestrator {
     } catch (err) {
       this.emit('trace-log', `ERROR: Chat request failed: ${err.message}`);
       return {
-        content: `Error from ${activeProvider}: ${err.message}\n\nPlease check your provider configuration in Settings.`,
+        content: `Error from ${activeProvider}: ${err.message}\n\n${providerSetupGuidance(activeProvider, settings)}`,
         metadata: { model_used: 'error', tokens_in: 0, tokens_out: 0 }
       };
     }

--- a/node-backend/lib/skills.mjs
+++ b/node-backend/lib/skills.mjs
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -154,6 +155,42 @@ function parseMarkdownSkill(filePath, markdown, metadata = null) {
   };
 }
 
+function parseFrontmatter(markdown) {
+  const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!match) return { metadata: null, body: markdown };
+
+  const metadata = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const separator = line.indexOf(':');
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim().replace(/^['"]|['"]$/g, '');
+    if (key) metadata[key] = value;
+  }
+
+  return { metadata, body: markdown.slice(match[0].length).trim() };
+}
+
+function parseDirectorySkill(dirPath, markdown) {
+  const id = path.basename(dirPath);
+  const { metadata, body } = parseFrontmatter(markdown);
+  const heading = body.match(/^#\s+(.+?)\s*$/m)?.[1]?.trim();
+  const now = new Date().toISOString();
+
+  return {
+    id,
+    name: metadata?.name || heading || id,
+    description: metadata?.description || body.split(/\r?\n/).find((line) => line.trim()) || `Skill loaded from ${id}/SKILL.md`,
+    capabilities: [],
+    prompt_template: body,
+    examples: [],
+    parameters: [],
+    version: metadata?.version || '1.0.0',
+    created: now,
+    updated: now,
+  };
+}
+
 async function loadSkillFromFile(filePath) {
   const markdown = await fs.readFile(filePath, 'utf8');
   const id = path.basename(filePath, '.md');
@@ -167,6 +204,12 @@ async function loadSkillFromFile(filePath) {
   return parseMarkdownSkill(filePath, markdown, metadata);
 }
 
+async function loadSkillFromDirectory(dirPath) {
+  const skillPath = path.join(dirPath, 'SKILL.md');
+  const markdown = await fs.readFile(skillPath, 'utf8');
+  return parseDirectorySkill(dirPath, markdown);
+}
+
 export async function listSkills() {
   const skillsDir = await getSkillsDir();
   await fs.mkdir(skillsDir, { recursive: true });
@@ -175,13 +218,21 @@ export async function listSkills() {
   const skills = [];
 
   for (const entry of entries) {
-    if (!entry.isFile()) continue;
     if (entry.name.startsWith('.')) continue;
-    if (entry.name === 'template.md') continue;
-    if (!entry.name.endsWith('.md')) continue;
 
     try {
-      skills.push(await loadSkillFromFile(path.join(skillsDir, entry.name)));
+      const entryPath = path.join(skillsDir, entry.name);
+      if (entry.isDirectory()) {
+        if (await fileExists(path.join(entryPath, 'SKILL.md'))) {
+          skills.push(await loadSkillFromDirectory(entryPath));
+        }
+        continue;
+      }
+
+      if (!entry.isFile()) continue;
+      if (entry.name === 'template.md') continue;
+      if (!entry.name.endsWith('.md')) continue;
+      skills.push(await loadSkillFromFile(entryPath));
     } catch {
       // Skip malformed skills in the prototype.
     }
@@ -194,12 +245,20 @@ export async function listSkills() {
 export async function getSkillById(skillId) {
   const skillsDir = await getSkillsDir();
   const filePath = path.join(skillsDir, `${skillId}.md`);
-  if (!await fileExists(filePath)) {
+  if (await fileExists(filePath)) {
+    return loadSkillFromFile(filePath);
+  }
+
+  const dirPath = path.join(skillsDir, skillId);
+  if (await fileExists(path.join(dirPath, 'SKILL.md'))) {
+    return loadSkillFromDirectory(dirPath);
+  }
+
+  {
     const error = new Error(`Skill not found: ${skillId}`);
     error.statusCode = 404;
     throw error;
   }
-  return loadSkillFromFile(filePath);
 }
 
 export function validateSkill(skill) {
@@ -294,8 +353,9 @@ export async function deleteSkill(skillId) {
   const skillsDir = await getSkillsDir();
   const markdownPath = path.join(skillsDir, `${skillId}.md`);
   const sidecarPath = path.join(skillsDir, '.metadata', `${skillId}.json`);
+  const dirPath = path.join(skillsDir, skillId);
 
-  if (!await fileExists(markdownPath)) {
+  if (!await fileExists(markdownPath) && !await fileExists(path.join(dirPath, 'SKILL.md'))) {
     const error = new Error(`Skill not found: ${skillId}`);
     error.statusCode = 404;
     throw error;
@@ -303,6 +363,23 @@ export async function deleteSkill(skillId) {
 
   await fs.rm(markdownPath, { force: true });
   await fs.rm(sidecarPath, { force: true });
+  await fs.rm(dirPath, { recursive: true, force: true });
+}
+
+function normalizeSkillsCommand(rawCommand) {
+  const command = String(rawCommand || '').trim();
+  if (!/^npx(\s+--yes|\s+-y)?\s+skills\s+add\s+/i.test(command)) {
+    const error = new Error('Skill import only supports commands in the form: npx skills add <repo> --skill <name>');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const additions = [];
+  if (!/(^|\s)(--yes|-y)(\s|$)/i.test(command)) additions.push('--yes');
+  if (!/(^|\s)--agent(\s|=)/i.test(command) && !/(^|\s)-a\s+/i.test(command)) additions.push('--agent openclaw');
+  if (!/(^|\s)--copy(\s|$)/i.test(command)) additions.push('--copy');
+
+  return [command, ...additions].join(' ');
 }
 
 export async function getSkillsByCategory(category) {
@@ -315,15 +392,33 @@ export async function importSkill(npxCommand) {
   const skillsDir = await getSkillsDir();
   await fs.mkdir(skillsDir, { recursive: true });
 
-  console.log(`[SkillsService] Importing skill using command: ${npxCommand}`);
+  const normalizedCommand = normalizeSkillsCommand(npxCommand);
+  console.log(`[SkillsService] Importing skill using command: ${normalizedCommand}`);
   
   // Before running the command, list current skills
   const before = await listSkills();
+  const importWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), 'productos-skill-import-'));
   
   try {
-    // Run the npx command. We set CWD to the skills directory so the command 
-    // can drop its files there.
-    await execPromise(npxCommand, { cwd: skillsDir, timeout: 60000 });
+    // Run the skills CLI in an isolated workspace. The CLI writes OpenClaw skills
+    // under ./skills/<name>/SKILL.md; we then copy only those skill folders into
+    // productOS' managed skills directory.
+    await execPromise(normalizedCommand, { cwd: importWorkspace, timeout: 120000 });
+
+    const importedSkillsDir = path.join(importWorkspace, 'skills');
+    if (await fileExists(importedSkillsDir)) {
+      const entries = await fs.readdir(importedSkillsDir, { withFileTypes: true });
+      for (const entry of entries) {
+        const source = path.join(importedSkillsDir, entry.name);
+        const destination = path.join(skillsDir, entry.name);
+        if (entry.isDirectory() && await fileExists(path.join(source, 'SKILL.md'))) {
+          await fs.rm(destination, { recursive: true, force: true });
+          await fs.cp(source, destination, { recursive: true });
+        } else if (entry.isFile() && entry.name.endsWith('.md')) {
+          await fs.copyFile(source, destination);
+        }
+      }
+    }
     
     // After running, re-list and find the new one
     const after = await listSkills();
@@ -341,5 +436,7 @@ export async function importSkill(npxCommand) {
     const err = new Error(`Failed to run import command: ${error.message}`);
     err.statusCode = 500;
     throw err;
+  } finally {
+    await fs.rm(importWorkspace, { recursive: true, force: true });
   }
 }

--- a/node-backend/lib/skills.mjs
+++ b/node-backend/lib/skills.mjs
@@ -205,8 +205,18 @@ async function loadSkillFromFile(filePath) {
 }
 
 async function loadSkillFromDirectory(dirPath) {
+  const skillId = path.basename(dirPath);
   const skillPath = path.join(dirPath, 'SKILL.md');
+  const skillsDir = path.dirname(dirPath);
+  const sidecarPath = path.join(skillsDir, '.metadata', `${skillId}.json`);
+
   const markdown = await fs.readFile(skillPath, 'utf8');
+  
+  if (await fileExists(sidecarPath)) {
+    const metadata = JSON.parse(await fs.readFile(sidecarPath, 'utf8'));
+    return parseMarkdownSkill(skillPath, markdown, metadata);
+  }
+  
   return parseDirectorySkill(dirPath, markdown);
 }
 
@@ -229,10 +239,7 @@ export async function listSkills() {
         continue;
       }
 
-      if (!entry.isFile()) continue;
-      if (entry.name === 'template.md') continue;
-      if (!entry.name.endsWith('.md')) continue;
-      skills.push(await loadSkillFromFile(entryPath));
+      // Flat .md skills are deprecated.
     } catch {
       // Skip malformed skills in the prototype.
     }
@@ -244,11 +251,6 @@ export async function listSkills() {
 
 export async function getSkillById(skillId) {
   const skillsDir = await getSkillsDir();
-  const filePath = path.join(skillsDir, `${skillId}.md`);
-  if (await fileExists(filePath)) {
-    return loadSkillFromFile(filePath);
-  }
-
   const dirPath = path.join(skillsDir, skillId);
   if (await fileExists(path.join(dirPath, 'SKILL.md'))) {
     return loadSkillFromDirectory(dirPath);
@@ -325,7 +327,9 @@ export async function saveSkill(rawSkill) {
     throw error;
   }
 
-  const markdownPath = path.join(skillsDir, `${skill.id}.md`);
+  const skillDirPath = path.join(skillsDir, skill.id);
+  await fs.mkdir(skillDirPath, { recursive: true });
+  const markdownPath = path.join(skillDirPath, 'SKILL.md');
   const sidecarPath = path.join(skillsDir, '.metadata', `${skill.id}.json`);
   await fs.writeFile(markdownPath, skillToMarkdown(skill), 'utf8');
   await fs.writeFile(sidecarPath, JSON.stringify(metadataFromSkill(skill), null, 2), 'utf8');
@@ -351,17 +355,15 @@ export async function updateSkill(skill) {
 
 export async function deleteSkill(skillId) {
   const skillsDir = await getSkillsDir();
-  const markdownPath = path.join(skillsDir, `${skillId}.md`);
   const sidecarPath = path.join(skillsDir, '.metadata', `${skillId}.json`);
   const dirPath = path.join(skillsDir, skillId);
 
-  if (!await fileExists(markdownPath) && !await fileExists(path.join(dirPath, 'SKILL.md'))) {
+  if (!await fileExists(path.join(dirPath, 'SKILL.md'))) {
     const error = new Error(`Skill not found: ${skillId}`);
     error.statusCode = 404;
     throw error;
   }
 
-  await fs.rm(markdownPath, { force: true });
   await fs.rm(sidecarPath, { force: true });
   await fs.rm(dirPath, { recursive: true, force: true });
 }

--- a/node-backend/tests/services/skill-service.test.mjs
+++ b/node-backend/tests/services/skill-service.test.mjs
@@ -44,6 +44,27 @@ test('Skill Service - listSkills', async () => {
   assert.strictEqual(skills[1].name, 'Skill B');
 });
 
+test('Skill Service - listSkills supports OpenClaw SKILL.md directories', async () => {
+  const skillDir = path.join(tempSkillsDir, 'frontend-design');
+  await fs.mkdir(skillDir, { recursive: true });
+  await fs.writeFile(path.join(skillDir, 'SKILL.md'), `---
+name: frontend-design
+description: Create production-grade frontend interfaces.
+---
+
+Use this skill for UI design work.
+`, 'utf8');
+
+  const skills = await listSkills();
+  assert.strictEqual(skills.length, 1);
+  assert.strictEqual(skills[0].id, 'frontend-design');
+  assert.strictEqual(skills[0].name, 'frontend-design');
+  assert.match(skills[0].description, /production-grade frontend/);
+
+  const loaded = await getSkillById('frontend-design');
+  assert.strictEqual(loaded.prompt_template, 'Use this skill for UI design work.');
+});
+
 test('Skill Service - updateSkill', async () => {
   const skill = await createSkill({ name: 'Old Skill', description: 'Old', prompt_template: 'Old' });
   skill.name = 'New Skill';

--- a/node-backend/tests/services/skill-service.test.mjs
+++ b/node-backend/tests/services/skill-service.test.mjs
@@ -29,9 +29,10 @@ test('Skill Service - createSkill', async () => {
   assert.strictEqual(skill.name, 'Test Skill');
   assert.strictEqual(skill.id, 'test-skill');
   assert.strictEqual(skill.prompt_template, 'Hello {{name}}');
-  
   const files = await fs.readdir(tempSkillsDir);
-  assert.ok(files.includes('test-skill.md'));
+  assert.ok(files.includes('test-skill'));
+  const skillFiles = await fs.readdir(path.join(tempSkillsDir, 'test-skill'));
+  assert.ok(skillFiles.includes('SKILL.md'));
 });
 
 test('Skill Service - listSkills', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1083,9 +1083,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3303,9 +3303,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3323,9 +3320,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3343,9 +3337,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3363,9 +3354,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3383,9 +3371,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3403,9 +3388,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7130,9 +7112,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -7147,9 +7129,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "dev": true,
       "funding": [
         {
@@ -7159,7 +7141,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -8845,9 +8828,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8869,9 +8849,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8893,9 +8870,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8917,9 +8891,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13971,6 +13942,22 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/src/components/workspace/ImportSkillDialog.tsx
+++ b/src/components/workspace/ImportSkillDialog.tsx
@@ -56,7 +56,7 @@ export default function ImportSkillDialog({ open, onOpenChange, onImport }: Impo
                 <DialogHeader>
                     <DialogTitle>Import Skill</DialogTitle>
                     <DialogDescription>
-                        Find and import skills from the official registry. productOS installs them non-interactively for OpenClaw.
+                        Find and import skills from the official registry. ProductOS installs them non-interactively for OpenClaw.
                     </DialogDescription>
                 </DialogHeader>
 
@@ -71,7 +71,7 @@ export default function ImportSkillDialog({ open, onOpenChange, onImport }: Impo
                                     </a> and search for a skill.
                                 </li>
                                 <li>Copy the <b>npx skills add</b> command from the skill page.</li>
-                                <li>Paste the command below. If needed, productOS adds <code>--yes --agent openclaw --copy</code> so the import does not stop at an interactive prompt.</li>
+                                <li>Paste the command below. If needed, ProductOS adds <code>--yes --agent openclaw --copy</code> so the import does not stop at an interactive prompt.</li>
                             </ol>
                         </div>
 

--- a/src/components/workspace/ImportSkillDialog.tsx
+++ b/src/components/workspace/ImportSkillDialog.tsx
@@ -56,7 +56,7 @@ export default function ImportSkillDialog({ open, onOpenChange, onImport }: Impo
                 <DialogHeader>
                     <DialogTitle>Import Skill</DialogTitle>
                     <DialogDescription>
-                        Find and import skills from the official registry.
+                        Find and import skills from the official registry. productOS installs them non-interactively for OpenClaw.
                     </DialogDescription>
                 </DialogHeader>
 
@@ -70,8 +70,8 @@ export default function ImportSkillDialog({ open, onOpenChange, onImport }: Impo
                                         skills.sh
                                     </a> and search for a skill.
                                 </li>
-                                <li>Copy the <b>npx</b> command from the skill page.</li>
-                                <li>Paste the command below to import it.</li>
+                                <li>Copy the <b>npx skills add</b> command from the skill page.</li>
+                                <li>Paste the command below. If needed, productOS adds <code>--yes --agent openclaw --copy</code> so the import does not stop at an interactive prompt.</li>
                             </ol>
                         </div>
 
@@ -81,7 +81,7 @@ export default function ImportSkillDialog({ open, onOpenChange, onImport }: Impo
                                 id="npx-command"
                                 value={npxCommand}
                                 onChange={(e) => setNpxCommand(e.target.value)}
-                                placeholder="npx skills add ..."
+                                placeholder="npx skills add https://github.com/anthropics/skills --skill frontend-design"
                                 disabled={isLoading}
                                 onKeyDown={(e) => {
                                     if (e.key === 'Enter' && !isLoading && npxCommand.trim()) {

--- a/src/hooks/useWorkspaceInit.ts
+++ b/src/hooks/useWorkspaceInit.ts
@@ -39,9 +39,11 @@ export function useWorkspaceInit({
                     appApi.getAllProjects()
                 ]);
 
+                const normalizedSettings = { ...settings, theme: settings.theme || 'dark' };
+
                 setSkills(skills);
-                setGlobalSettings(settings);
-                if (settings.theme) setTheme(settings.theme);
+                setGlobalSettings(normalizedSettings);
+                setTheme(normalizedSettings.theme);
 
                 const workspaceProjects = projectsList.map((p: any) => ({
                     ...p,
@@ -51,9 +53,8 @@ export function useWorkspaceInit({
                 }));
                 setProjects(workspaceProjects);
 
-                if (settings.theme) {
-                    document.documentElement.classList.toggle('dark', settings.theme === 'dark');
-                }
+                document.documentElement.classList.remove('light', 'dark');
+                document.documentElement.classList.add(normalizedSettings.theme === 'system' ? 'dark' : normalizedSettings.theme);
 
                 const lastProject = settings.lastProjectId
                     ? workspaceProjects.find((p: any) => p.id === settings.lastProjectId)

--- a/src/pages/GlobalSettings.tsx
+++ b/src/pages/GlobalSettings.tsx
@@ -158,8 +158,8 @@ export default function GlobalSettingsPage({ initialSection }: { initialSection?
 
         // Merge default templates
         const mergedSettings: GlobalSettings = {
-          theme: 'dark',
           ...(loadedSettings || {}),
+          theme: loadedSettings?.theme ?? 'dark',
           artifactTemplates: {
             ...DEFAULT_TEMPLATES,
             ...((loadedSettings?.artifactTemplates) || {})

--- a/src/pages/GlobalSettings.tsx
+++ b/src/pages/GlobalSettings.tsx
@@ -158,6 +158,7 @@ export default function GlobalSettingsPage({ initialSection }: { initialSection?
 
         // Merge default templates
         const mergedSettings: GlobalSettings = {
+          theme: 'dark',
           ...(loadedSettings || {}),
           artifactTemplates: {
             ...DEFAULT_TEMPLATES,

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -179,6 +179,7 @@ export default function Onboarding({ onComplete, onSkip }: OnboardingProps) {
       const current = await appApi.getGlobalSettings();
       await appApi.saveGlobalSettings({
         ...current,
+        theme: current.theme || 'dark',
         // No default provider forced here; only persist explicit user selection.
         activeProvider: selectedProvider ? (selectedProvider as any) : current.activeProvider,
         selectedProviders: selectedProvider ? [selectedProvider] : current.selectedProviders,

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -104,7 +104,7 @@ export default function Workspace() {
   const [activeProject, setActiveProject] = useState<WorkspaceProject | null>(null);
   const [activeWorkflow, setActiveWorkflow] = useState<Workflow | null>(null);
   const [activeTab, setActiveTab] = useState('products');
-  const [theme, setTheme] = useState('system');
+  const [theme, setTheme] = useState('dark');
   const resolvedTheme = theme === 'system' ? 'dark' : theme;
   const [showFileDialog, setShowFileDialog] = useState(false);
   const [showFindDialog, setShowFindDialog] = useState(false);


### PR DESCRIPTION
## Summary
- Document source-install prerequisites, OpenCode setup, PM-friendly release path, and skill/chat troubleshooting
- Keep first-run/settings/workspace theme consistently dark unless the user explicitly changes it
- Make skill import non-interactive by normalizing `npx skills add ...` with OpenClaw flags and loading `SKILL.md` directory imports
- Improve chat provider setup errors with provider-specific next steps and active/selected provider mismatch hints

## Verification
- `npm run build`
- `npm run test:backend`
- Manual skill import smoke test: `npx skills add https://github.com/anthropics/skills --skill frontend-design` imported `frontend-design` successfully via backend service


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenCode as an optional custom CLI integration
  * Support for directory-based skill format (SKILL.md)
  * Enhanced skill importing workflow

* **Bug Fixes**
  * Improved provider setup error messages with specific guidance

* **Documentation**
  * Updated installation instructions with Build from Source section
  * Expanded troubleshooting and provider configuration guidance
  * Updated skill import instructions and examples

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AIResearchFactory/productOS/pull/159)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->