### PR TITLE
fix(e2e): stabilize settings and workspace state

### DIFF
--- a/scripts/stop-dev.js
+++ b/scripts/stop-dev.js
@@ -34,28 +34,15 @@ async function stop() {
     // 2. Aggressively kill any remaining processes on relevant ports
     const ports = [5173, 51423];
     for (const port of ports) {
-        try {
-            // Find all PIDs using lsof
-            const lsofOutput = execSync(`lsof -t -i:${port}`, { encoding: 'utf8' }).trim();
-            if (lsofOutput) {
-                const pids = lsofOutput.split(/\s+/).filter(Boolean);
-                console.log(`Found ${pids.length} process(es) on port ${port}: ${pids.join(', ')}`);
-
-                for (const pid of pids) {
-                    try {
-                        console.log(`  - Killing PID ${pid}...`);
-                        execSync(`kill -9 ${pid}`);
-                        console.log(`  ✓ PID ${pid} terminated.`);
-                    } catch (killErr) {
-                        console.log(`  ! Failed to kill PID ${pid}: ${killErr.message}`);
-                    }
-                }
-            } else {
-                console.log(`✓ No processes found on port ${port}.`);
-            }
-        } catch (e) {
-            // execSync fails if lsof returns nothing (no process found)
+        const pids = findPidsForPort(port);
+        if (pids.length === 0) {
             console.log(`✓ Port ${port} is clear.`);
+            continue;
+        }
+
+        console.log(`Found ${pids.length} process(es) on port ${port}: ${pids.join(', ')}`);
+        for (const pid of pids) {
+            killPid(pid);
         }
     }
 
@@ -68,6 +55,48 @@ async function stop() {
         openBrowser(`file://${landingPath}`);
     }
     */
+}
+
+function findPidsForPort(port) {
+    if (process.platform === 'win32') {
+        try {
+            const output = execSync(`netstat -ano -p tcp | findstr :${port}`, { encoding: 'utf8' });
+            return [...new Set(output
+                .split(/\r?\n/)
+                .map((line) => line.trim().split(/\s+/))
+                .filter((parts) => parts.length >= 5)
+                .filter((parts) => {
+                    const localAddress = parts[1] || '';
+                    const state = parts[3] || '';
+                    return localAddress.endsWith(`:${port}`) && /^(LISTENING|ESTABLISHED)$/i.test(state);
+                })
+                .map((parts) => parts[4])
+                .filter(Boolean))];
+        } catch {
+            return [];
+        }
+    }
+
+    try {
+        const lsofOutput = execSync(`lsof -t -i:${port}`, { encoding: 'utf8' }).trim();
+        return lsofOutput ? [...new Set(lsofOutput.split(/\s+/).filter(Boolean))] : [];
+    } catch {
+        return [];
+    }
+}
+
+function killPid(pid) {
+    try {
+        console.log(`  - Killing PID ${pid}...`);
+        if (process.platform === 'win32') {
+            execSync(`taskkill /PID ${pid} /T /F`, { stdio: 'ignore' });
+        } else {
+            execSync(`kill -9 ${pid}`);
+        }
+        console.log(`  ✓ PID ${pid} terminated.`);
+    } catch (killErr) {
+        console.log(`  ! Failed to kill PID ${pid}: ${killErr.message}`);
+    }
 }
 
 // ── Open browser helper ──────────────────────────────────────────────

--- a/src/components/workflow/WorkflowBuilderDialog.tsx
+++ b/src/components/workflow/WorkflowBuilderDialog.tsx
@@ -42,6 +42,7 @@ export default function WorkflowBuilderDialog({
   const [integrationsEnabled, setIntegrationsEnabled] = useState(false);
   const [saving, setSaving] = useState(false);
   const [currentStep, setCurrentStep] = useState(1);
+  const projectOptionsKey = useMemo(() => projects.map((p) => p.id).join('|'), [projects]);
 
   useEffect(() => {
     if (!open) {
@@ -67,7 +68,19 @@ export default function WorkflowBuilderDialog({
       }
     };
     checkIntegrations();
-  }, [open, initialWorkflow, initialProjectId, projects]);
+  }, [open, initialWorkflow?.id]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const availableProjectIds = new Set(projects.map((p) => p.id));
+    const preferredProjectId = initialWorkflow?.project_id || initialProjectId || projects[0]?.id || '';
+
+    setProjectId((current) => {
+      if (current && availableProjectIds.has(current)) return current;
+      return preferredProjectId;
+    });
+  }, [open, projectOptionsKey, initialProjectId, initialWorkflow?.project_id]);
 
   const presets = useMemo(() => ([
     { label: 'Daily 08:00', cron: '0 8 * * *' },

--- a/src/components/workspace/MainPanel.tsx
+++ b/src/components/workspace/MainPanel.tsx
@@ -188,11 +188,13 @@ export default function MainPanel({
   // Chat is visible unless: user toggled it off while a doc is open, or global-settings is active
   const shouldShowChat = layoutMode !== 'hidden' && !isGlobalSettings;
 
-  // Show editor when a non-chat doc is open and no workflow is active
+  // Show editor/content when a non-chat doc is open and no workflow is active.
+  // Global settings is rendered through this content area; hiding it here leaves
+  // the settings document active but invisible.
   const shouldShowEditor = isDocOpen && !isChatDoc && !activeWorkflow;
 
   // Content area exists when showing a workflow canvas, an editor doc, or an empty state (no docs)
-  const hasContentArea = (!!activeWorkflow || shouldShowEditor || (openDocuments.length === 0 && !isChatDoc && !isGlobalSettings)) && layoutMode !== 'full';
+  const hasContentArea = (!!activeWorkflow || shouldShowEditor || (openDocuments.length === 0 && !isChatDoc)) && layoutMode !== 'full';
   
   const useStackedContent = viewportWidth < 1100 && hasContentArea && shouldShowChat;
   

--- a/src/pages/GlobalSettings.tsx
+++ b/src/pages/GlobalSettings.tsx
@@ -732,6 +732,17 @@ export default function GlobalSettingsPage({ initialSection, initialProjectId }:
   };
 
   const renderContent = () => {
+    if (loading) {
+      return (
+        <div className="flex items-center justify-center min-h-[320px]">
+          <div className="flex flex-col items-center gap-4">
+            <Loader2 className="w-8 h-8 animate-spin text-primary" />
+            <p className="text-sm font-medium text-gray-500">Initializing settings engine...</p>
+          </div>
+        </div>
+      );
+    }
+
     switch (activeSection) {
         case 'ai':
             return (
@@ -925,17 +936,6 @@ export default function GlobalSettingsPage({ initialSection, initialProjectId }:
         default: return '';
     }
   };
-
-  if (loading) {
-    return (
-        <div className="flex items-center justify-center h-full bg-white dark:bg-gray-950">
-            <div className="flex flex-col items-center gap-4">
-                <Loader2 className="w-8 h-8 animate-spin text-primary" />
-                <p className="text-sm font-medium text-gray-500">Initializing settings engine...</p>
-            </div>
-        </div>
-    );
-  }
 
   return (
     <div data-testid="settings-page" className="h-full">

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -126,6 +126,49 @@ export default function Workspace() {
   const [showChat, setShowChat] = useState(false);
   const [updateAvailable, setUpdateAvailable] = useState(false);
 
+  useEffect(() => {
+    const projectId = activeProject?.id;
+    if (!projectId || projectId === 'new-project') return;
+
+    let cancelled = false;
+
+    const loadActiveProjectState = async () => {
+      try {
+        const [files, projectWorkflows, projectArtifacts] = await Promise.all([
+          appApi.getProjectFiles(projectId),
+          appApi.getProjectWorkflows(projectId),
+          appApi.listArtifacts(projectId),
+        ]);
+
+        if (cancelled || activeProjectRef.current?.id !== projectId) return;
+
+        const docs = files.map((fileName: string) => ({
+          id: fileName,
+          name: fileName,
+          type: fileName.startsWith('chat-') ? 'chat' : 'document',
+          content: '',
+        }));
+
+        setProjects(prev => prev.map((p: WorkspaceProject) => p.id === projectId ? { ...p, documents: docs } : p));
+        setActiveProject(prev => prev?.id === projectId ? { ...prev, documents: docs } : prev);
+        setWorkflows(projectWorkflows);
+        setArtifacts(projectArtifacts);
+      } catch (error) {
+        if (!cancelled && activeProjectRef.current?.id === projectId) {
+          console.error('Failed to refresh active project state:', error);
+          setWorkflows([]);
+          setArtifacts([]);
+        }
+      }
+    };
+
+    loadActiveProjectState();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeProject?.id]);
+
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -895,6 +938,9 @@ export default function Workspace() {
         setActiveProject(null);
         setOpenDocuments([]);
         setActiveDocument(null);
+        setActiveWorkflow(null);
+        setWorkflows([]);
+        setArtifacts([]);
         
         // Clear last project ID
         try {


### PR DESCRIPTION
## Summary
- keep global settings visible while its data is still loading so settings nav/test IDs are stable
- reload active project files/workflows/artifacts when the active project changes
- clear workflow/artifact state when deleting the active project to avoid stale 404 requests
- preserve workflow dialog project selection when projects load asynchronously
- make npm run stop work on Windows by using netstat/taskkill instead of lsof/kill

## Verification
- npm run build
- npm run test:e2e -- e2e/settings.spec.ts --reporter=line

## Follow-up in progress
- continuing focused usage/workflows/onboarding E2E fixes on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved global settings visibility and accessibility within the workspace layout.
  * Enhanced project state synchronization when switching between projects to ensure files, workflows, and artifacts are properly refreshed.
  * Fixed cleanup behavior when deleting the currently active project to prevent orphaned workflow state.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AIResearchFactory/productOS/pull/165)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->