### PR TITLE
chore: bump version to 0.3.3

### DIFF
--- a/node-backend/server.mjs
+++ b/node-backend/server.mjs
@@ -220,7 +220,7 @@ async function handleRequest(req, res) {
   if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/index.html')) {
     return sendJson(res, 200, { 
       message: 'productos API (Node) is running',
-      version: '0.3.0-node',
+      version: '0.3.3-node',
       health: '/api/health',
       frontend: 'http://localhost:5173'
     });
@@ -231,7 +231,7 @@ async function handleRequest(req, res) {
   }
 
   if (req.method === 'GET' && (url.pathname === '/api/health' || url.pathname === '/api/system/health')) {
-    return sendJson(res, 200, { ok: true, status: 'ok', version: '0.3.0-node', runtime: 'node-prototype' });
+    return sendJson(res, 200, { ok: true, status: 'ok', version: '0.3.3-node', runtime: 'node-prototype' });
   }
 
   if (req.method === 'GET' && url.pathname === '/api/system/data-directory') {
@@ -475,14 +475,14 @@ async function handleRequest(req, res) {
       // Fallback to a default policy instead of returning 404
       return sendJson(res, 200, {
         min_supported_version: '0.1.0',
-        latest_version: '0.3.0',
+        latest_version: '0.3.3',
         message: 'Running in local development mode.'
       });
     } catch (error) {
       // Even on error, return a default policy to avoid 404 console errors
       return sendJson(res, 200, {
         min_supported_version: '0.1.0',
-        latest_version: '0.3.0',
+        latest_version: '0.3.3',
         message: 'Update policy check unavailable.'
       });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "productos",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "productos",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-context-menu": "2.2.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "productos",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": false,
   "description": "Local-first AI-powered research command center for product management.",
   "author": "AIResearchFactory",


### PR DESCRIPTION
Next Steps for Publishing
Since I do not have active npm credentials in this environment, you will need to perform the final publish step. Once you merge the [Pull Request](https://github.com/AIResearchFactory/productOS/pull/new/chore/bump-version-0.3.3), run the following command from your terminal:

bash
npm publish
This will automatically trigger the prepublishOnly script (which runs npm run build) before pushing the package to the registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 0.3.3 throughout the system, including API health endpoints and system update policy responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AIResearchFactory/productOS/pull/167)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->