### PR TITLE
fix(workspace): support relative path artifact IDs in frontend to pre…

### DIFF
--- a/src/components/workspace/ArtifactList.tsx
+++ b/src/components/workspace/ArtifactList.tsx
@@ -201,7 +201,9 @@ export default function ArtifactList({
                                                     default: return 'artifacts';
                                                 }
                                             };
-                                            const fileName = `${getArtifactDirectory(artifact.artifactType)}/${artifact.id}.md`;
+                                            const fileName = artifact.id.includes('/') && artifact.id.endsWith('.md')
+                                                ? artifact.id
+                                                : `${getArtifactDirectory(artifact.artifactType)}/${artifact.id}.md`;
                                             const artifactDoc = {
                                                 id: fileName,
                                                 name: fileName,

--- a/src/components/workspace/Sidebar.tsx
+++ b/src/components/workspace/Sidebar.tsx
@@ -504,7 +504,9 @@ export default function Sidebar({
                                                   default: return 'artifacts';
                                                 }
                                               };
-                                              const fileName = `${getArtifactDirectory(artifact.artifactType)}/${artifact.id}.md`;
+                                              const fileName = artifact.id.includes('/') && artifact.id.endsWith('.md')
+                                                ? artifact.id
+                                                : `${getArtifactDirectory(artifact.artifactType)}/${artifact.id}.md`;
                                               const artifactDoc = {
                                                 id: fileName,
                                                 name: fileName,

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -2451,7 +2451,9 @@ export default function Workspace() {
                   default: return 'artifacts';
                 }
               };
-              const fileName = `${getArtifactDirectory(artifact.artifactType)}/${artifact.id}.md`;
+              const fileName = artifact.id.includes('/') && artifact.id.endsWith('.md')
+                ? artifact.id
+                : `${getArtifactDirectory(artifact.artifactType)}/${artifact.id}.md`;
               const doc: Document = {
                 id: fileName,
                 name: fileName,
@@ -2499,7 +2501,9 @@ export default function Workspace() {
                     default: return 'artifacts';
                   }
                 };
-                const fileName = `${getArtifactDirectory(artifact.artifactType)}/${artifact.id}.md`;
+                const fileName = artifact.id.includes('/') && artifact.id.endsWith('.md')
+                  ? artifact.id
+                  : `${getArtifactDirectory(artifact.artifactType)}/${artifact.id}.md`;
                 const doc: Document = {
                   id: fileName,
                   name: fileName,
@@ -2632,7 +2636,9 @@ export default function Workspace() {
                   default: return 'artifacts';
                 }
               };
-              const fileName = `${getArtifactDirectory(artifact.artifactType)}/${artifact.id}.md`;
+              const fileName = artifact.id.includes('/') && artifact.id.endsWith('.md')
+                ? artifact.id
+                : `${getArtifactDirectory(artifact.artifactType)}/${artifact.id}.md`;
               const doc: Document = {
                 id: fileName,
                 name: fileName,


### PR DESCRIPTION
…vent duplicated paths

Handles relative paths correctly in path construction routines across Sidebar, ArtifactList, and Workspace pages, resolving issues where artifacts failed to load due to duplicated parent directories and extensions in the generated path.