### PR TITLE
fix(ux): make chat the primary workspace

### DIFF
--- a/src/components/workspace/MainPanel.tsx
+++ b/src/components/workspace/MainPanel.tsx
@@ -105,64 +105,15 @@ export default function MainPanel({
   onSendPrompt,
   artifacts = []
 }: MainPanelProps) {
-  const [layoutMode, setLayoutMode] = useState<'split' | 'full' | 'hidden'>(showChat ? 'split' : 'hidden');
-  const [chatWidth, setChatWidth] = useState(40); // Percentage
-  const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
-  const isResizing = useRef(false);
-  const [isResizingState, setIsResizingState] = useState(false);
+  const [layoutMode, setLayoutMode] = useState<'split' | 'full' | 'hidden'>(showChat ? 'full' : 'hidden');
 
   useEffect(() => {
-    if (showChat && layoutMode === 'hidden') {
-      setLayoutMode('split');
-    } else if (!showChat && layoutMode !== 'hidden') {
-      setLayoutMode('hidden');
-    }
+    setLayoutMode(showChat ? 'full' : 'hidden');
   }, [showChat]);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const startResizing = () => {
-    isResizing.current = true;
-    setIsResizingState(true);
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', stopResizing);
-    document.body.style.cursor = 'col-resize';
-  };
-
-  const stopResizing = () => {
-    isResizing.current = false;
-    setIsResizingState(false);
-    document.removeEventListener('mousemove', handleMouseMove);
-    document.removeEventListener('mouseup', stopResizing);
-    document.body.style.cursor = 'default';
-  };
-
-  const handleMouseMove = (e: MouseEvent) => {
-    if (!isResizing.current || !containerRef.current) return;
-
-    // Calculate percentage from right relative to container
-    const containerRect = containerRef.current.getBoundingClientRect();
-    const containerWidth = containerRect.width;
-    const mouseXRelative = e.clientX - containerRect.left;
-
-    // Distance from right edge
-    const offsetFromRight = containerWidth - mouseXRelative;
-
-    const percentage = (offsetFromRight / containerWidth) * 100;
-
-    // Constrain between 20% and 80%
-    if (percentage > 20 && percentage < 80) {
-      setChatWidth(percentage);
-    }
-  };
-
   const tabsContainerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handleResize = () => setViewportWidth(window.innerWidth);
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
 
   // Auto-scroll to active tab
   useEffect(() => {
@@ -193,31 +144,21 @@ export default function MainPanel({
   // the settings document active but invisible.
   const shouldShowEditor = isDocOpen && !isChatDoc && !activeWorkflow;
 
-  // Content area exists when showing a workflow canvas, an editor doc, or an empty state (no docs)
-  const hasContentArea = (!!activeWorkflow || shouldShowEditor || (openDocuments.length === 0 && !isChatDoc)) && layoutMode !== 'full';
-  
-  const useStackedContent = viewportWidth < 1100 && hasContentArea && shouldShowChat;
-  
-  const contentStyle = useStackedContent
-    ? { width: '100%', height: '58%' }
-    : { width: shouldShowChat && hasContentArea ? `${100 - chatWidth}%` : (hasContentArea ? '100%' : '0%'), display: hasContentArea ? 'flex' : 'none' };
-    
-  const chatStyle = shouldShowChat
-    ? (hasContentArea
-      ? useStackedContent
-        ? { width: '100%', height: '42%' }
-        : { width: `${chatWidth}%` }
-      : { width: '100%', flex: 1 })
-    : { width: 0, overflow: 'hidden' };
+  const hasContentArea = !!activeWorkflow || shouldShowEditor || (openDocuments.length === 0 && !isChatDoc && !isGlobalSettings);
+
+  // When chat is open, it gets the full stage; the workspace collapses out of the way.
+  const showWorkspacePane = hasContentArea && !shouldShowChat;
+  const contentStyle = showWorkspacePane ? { width: '100%' } : { width: 0, overflow: 'hidden' };
+  const chatStyle = shouldShowChat ? { width: '100%' } : { width: 0, overflow: 'hidden' };
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-transparent font-sans relative">
-      <div ref={containerRef} className={`flex-1 ${useStackedContent ? 'flex flex-col' : 'flex'} overflow-hidden relative`}>
+      <div ref={containerRef} className="flex-1 flex overflow-hidden relative">
 
         {/* Content Area — Workflow Canvas OR Editor (only when needed) */}
-        {hasContentArea && (
+        {showWorkspacePane && (
           <div
-            className={`flex min-w-0 flex-col overflow-hidden ${isResizingState ? '' : 'transition-all duration-300 ease-in-out'} ${!activeWorkflow ? `${useStackedContent ? 'border-b' : 'border-r'} border-border bg-background/35 backdrop-blur-xl` : ''}`}
+            className={`flex min-w-0 flex-col overflow-hidden transition-all duration-300 ease-in-out ${!activeWorkflow ? 'border-r border-border bg-background/35 backdrop-blur-xl' : ''}`}
             style={contentStyle}
           >
             {activeWorkflow ? (
@@ -427,18 +368,9 @@ export default function MainPanel({
           </div>
         )}
 
-        {/* Resizer Handle (only when content area and chat are both visible) */}
-        {hasContentArea && shouldShowChat && !useStackedContent && (
-          <div
-            className="z-20 w-2 shrink-0 cursor-col-resize bg-muted transition-colors hover:bg-primary/40"
-            onMouseDown={startResizing}
-          />
-        )}
-
-        {/* Chat Panel — ALWAYS MOUNTED to preserve conversation state across navigation.
-            Visibility is controlled via width/flex, never by unmounting. */}
+        {/* Chat Panel — always mounted to preserve conversation state across navigation. */}
         <div
-          className={`flex flex-col overflow-hidden ${isResizingState ? '' : 'transition-all duration-300 ease-in-out'} ${hasContentArea ? 'shrink-0 bg-background/30 backdrop-blur-xl' : 'flex-1 bg-transparent'}`}
+          className={`flex flex-col overflow-hidden transition-all duration-300 ease-in-out ${hasContentArea ? 'shrink-0 bg-background/30 backdrop-blur-xl' : 'flex-1 bg-transparent'}`}
           style={chatStyle}
         >
           <ChatPanel

--- a/src/components/workspace/MainPanel.tsx
+++ b/src/components/workspace/MainPanel.tsx
@@ -105,11 +105,15 @@ export default function MainPanel({
   onSendPrompt,
   artifacts = []
 }: MainPanelProps) {
-  const [layoutMode, setLayoutMode] = useState<'split' | 'full' | 'hidden'>(showChat ? 'full' : 'hidden');
+  const [layoutMode, setLayoutMode] = useState<'split' | 'full' | 'hidden'>(showChat ? 'split' : 'hidden');
 
   useEffect(() => {
-    setLayoutMode(showChat ? 'full' : 'hidden');
-  }, [showChat]);
+    if (showChat && layoutMode === 'hidden') {
+      setLayoutMode('split');
+    } else if (!showChat && layoutMode !== 'hidden') {
+      setLayoutMode('hidden');
+    }
+  }, [showChat, layoutMode]);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -146,10 +150,15 @@ export default function MainPanel({
 
   const hasContentArea = !!activeWorkflow || shouldShowEditor || (openDocuments.length === 0 && !isChatDoc && !isGlobalSettings);
 
-  // When chat is open, it gets the full stage; the workspace collapses out of the way.
-  const showWorkspacePane = hasContentArea && !shouldShowChat;
-  const contentStyle = showWorkspacePane ? { width: '100%' } : { width: 0, overflow: 'hidden' };
-  const chatStyle = shouldShowChat ? { width: '100%' } : { width: 0, overflow: 'hidden' };
+  // Split view keeps the active workspace visible while making Copilot the
+  // companion panel. Full view is still available from the chat toolbar.
+  const showWorkspacePane = hasContentArea && layoutMode !== 'full';
+  const contentStyle = showWorkspacePane
+    ? { width: shouldShowChat ? '60%' : '100%' }
+    : { width: 0, overflow: 'hidden' };
+  const chatStyle = shouldShowChat
+    ? { width: showWorkspacePane ? '40%' : '100%' }
+    : { width: 0, overflow: 'hidden' };
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-transparent font-sans relative">

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -2543,13 +2543,6 @@ export default function Workspace() {
             onToggleChat={() => setShowChat(!showChat)}
             onTabChange={setActiveTab}
             onCreateProject={handleNewProject}
-            onCreateFile={handleNewFile}
-            onCreateWorkflow={handleNewWorkflow}
-            onCreateArtifact={(artifactType: ArtifactType) => {
-              setActiveTab('artifacts');
-              setSelectedArtifactTypeToCreate(artifactType);
-              setShowCreateArtifactDialog(true);
-            }}
             onOpenProductSettings={() => handleDocumentOpen(projectSettingsDocument)}
             onArtifactUpdate={() => activeProject && handleProjectSelect(activeProject)}
             activeWorkflow={activeWorkflow}

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -415,6 +415,7 @@ export default function Workspace() {
 
   const handleProjectSelect = async (project: WorkspaceProject) => {
     setActiveProject(project);
+    setShowChat(true);
 
     try {
       // Load project files from backend
@@ -2542,6 +2543,13 @@ export default function Workspace() {
             onToggleChat={() => setShowChat(!showChat)}
             onTabChange={setActiveTab}
             onCreateProject={handleNewProject}
+            onCreateFile={handleNewFile}
+            onCreateWorkflow={handleNewWorkflow}
+            onCreateArtifact={(artifactType: ArtifactType) => {
+              setActiveTab('artifacts');
+              setSelectedArtifactTypeToCreate(artifactType);
+              setShowCreateArtifactDialog(true);
+            }}
             onOpenProductSettings={() => handleDocumentOpen(projectSettingsDocument)}
             onArtifactUpdate={() => activeProject && handleProjectSelect(activeProject)}
             activeWorkflow={activeWorkflow}


### PR DESCRIPTION
## What\n- Collapse the main workspace pane when chat is open\n- Make chat the default when a project opens\n- Remove the side-by-side resize behavior so the chat gets the full stage\n\n## Verify\n- npx tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat panel now automatically opens when you select a project, keeping conversation history visible.

* **Improvements**
  * Chat and main workspace layout are now more consistent—panel visibility toggles more smoothly and stays mounted to avoid flicker.
  * Manual edge-resizing visuals and transition behaviors have been simplified for a cleaner appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AIResearchFactory/productOS/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->