### PR TITLE
fix: install Playwright after E2E dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,9 @@ jobs:
           npx wait-on --timeout 120000 "https://registry.npmjs.org/productos/${{ needs.publish.outputs.new_version }}"
           echo "Package is available!"
 
+      - name: Install E2E runner dependencies
+        run: npm ci
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
 
@@ -165,7 +168,6 @@ jobs:
       - name: Verify Installation (E2E)
         run: |
           echo "Running E2E tests against globally installed productos..."
-          npm ci # Install local deps for playwright runner
           PRODUCTOS_E2E_VERIFY_RELEASE=true CI=true npm run test:e2e:ci
         env:
           PROJECTS_DIR: ${{ github.workspace }}/.test-projects


### PR DESCRIPTION
## Summary
- install the repo E2E dependencies before installing Playwright browsers in release verification
- remove the second npm ci from the E2E verification step so the installed browser version matches the Playwright runner

## Why
The v0.4.1 release verification failed because Playwright browsers were installed before npm ci, so npx could resolve a different Playwright version than the one used by the E2E tests.

## Testing
- inspected the failed GitHub Actions run logs
- verified workflow diff only changes release verification ordering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow by reorganizing dependency installation steps for enhanced clarity and reliability during the release verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->