### PR TITLE
Fix/pptx content ordering and summarization

### DIFF
--- a/docs/features/pptx-content-fix/backend-plan.md
+++ b/docs/features/pptx-content-fix/backend-plan.md
@@ -82,8 +82,9 @@ New tests in `tests/presentation-layout.test.mjs`:
 | Multiple slides independent notes | No bleed between slides |
 | fullText mirrors speakerNotes | fullText is always in sync |
 
-## No Breaking Changes
+## Backward Compatibility & Contract Changes
 
-- The `SlideData` interface is unchanged
-- All existing layout rendering code (split, columns, timeline, etc.) is unaffected
-- The `speakerNotes` field was already part of the interface; we now always populate it from the parser
+- The `SlideData` interface is extended with optional fields (`elements`, `items`, `dominantVisualElement`, `primaryColorEmphasis`, `emotionalTone`) to support rich visual structuring.
+- Split and content layout rendering paths now iterate over `data.elements` when available for fine-grained styling and pagination, falling back to legacy fields (`bodyText`/`bullets`) if absent.
+- The `speakerNotes` field now consistently compiles the raw document's reading flow in exact interleaved order.
+- The new `spotlight` layout is registered in `SUPPORTED_LAYOUTS` and handled via `addSpotlightSlide`.

--- a/docs/features/pptx-content-fix/backend-plan.md
+++ b/docs/features/pptx-content-fix/backend-plan.md
@@ -1,0 +1,89 @@
+# Backend Plan: PPTX Content Ordering & Summarization Fix
+
+## Overview
+
+Two bugs fixed, one optimization improved — all in the frontend layer (no Node backend changes needed since PPTX export is entirely client-side via `pptxgenjs`).
+
+## Changes
+
+### 1. `src/lib/pptxExport.ts` — Parser fix
+
+**Function:** `parseMarkdownToSlides`
+
+**Problem:** Speaker notes were assembled AFTER the line loop by concatenating separate arrays:
+```js
+// OLD (broken ordering)
+speakerNotes = [...bodyText, ...bullets, ...subBullets.flat()].join('\n')
+```
+
+**Fix:** Build `orderedNotesLines[]` DURING the line loop. Each line is added to this array in the same order it's processed — so body paragraphs and bullets appear interleaved exactly as the author wrote them.
+
+```js
+// NEW (correct ordering)
+// During line processing:
+if (bulletMatch)   orderedNotesLines.push(`• ${bulletText}`);
+if (subBulletMatch) orderedNotesLines.push(`  • ${subText}`);
+if (bodyText)      orderedNotesLines.push(plainText);
+// After the loop:
+slide.speakerNotes = orderedNotesLines.join('\n');
+slide.fullText = slide.speakerNotes;
+```
+
+Sub-bullet ordering was also fixed: previously sub-bullets were matched AFTER bullets, which could cause them to appear before their parent bullet. Now sub-bullets are checked first (they have leading whitespace) before the generic bullet regex.
+
+**Speaker notes priority:** Explicit `**Speaker Notes:**` blocks in the markdown always override the auto-built ordered notes.
+
+---
+
+### 2. `src/components/workspace/MarkdownEditor.tsx` — Export handler fixes
+
+**Three changes in the PPTX download click handler:**
+
+#### Fix A — Fallback path notes (L533-554)
+```js
+// OLD: re-assembles notes with broken ordering
+const allText = [...s.bodyText, ...s.bullets, ...subBullets.flat()].join('\n');
+speakerNotes: allText
+
+// NEW: uses pre-built ordered notes from parser
+speakerNotes: s.speakerNotes || ''
+```
+
+#### Fix B — AI path notes (L637-641)
+```js
+// OLD: re-assembles notes with broken ordering
+const originalContent = [...bodyText, ...bullets, ...subBullets.flat()].join('\n');
+speakerNotes: originalContent
+
+// NEW: uses pre-built ordered notes from parser
+const orderedNotes = originalSection.speakerNotes || '';
+speakerNotes: orderedNotes
+```
+
+#### Fix C — AI prompt revision (L574-593)
+The old prompt asked the AI to generate content (bodyText/bullets) based on a truncated 800-char snippet. This caused information loss.
+
+The new prompt:
+- Sends full ordered notes text (from the parser) as context
+- Asks **only** for: `layoutHint`, `bullets` (3-4 summary points ≤10 words each), `bodyText` (0-1 kicker sentence)
+- **Explicitly forbids** the AI from returning speakerNotes or fullText
+- Removes the 800-char content cap (notes are now independent of AI output)
+- Adds detailed layout selection guidance (when to use columns/comparison/timeline/split)
+
+## Testing
+
+New tests in `tests/presentation-layout.test.mjs`:
+
+| Test | Verifies |
+|------|----------|
+| speakerNotes preserves interleaved order | Body text before bullets, bullets before body text that follows |
+| Sub-bullets after parent in notes | Correct nesting order in notes |
+| Explicit Speaker Notes overrides | `**Speaker Notes:**` block wins |
+| Multiple slides independent notes | No bleed between slides |
+| fullText mirrors speakerNotes | fullText is always in sync |
+
+## No Breaking Changes
+
+- The `SlideData` interface is unchanged
+- All existing layout rendering code (split, columns, timeline, etc.) is unaffected
+- The `speakerNotes` field was already part of the interface; we now always populate it from the parser

--- a/docs/features/pptx-content-fix/prd.md
+++ b/docs/features/pptx-content-fix/prd.md
@@ -1,0 +1,47 @@
+# PRD: Fix PPTX Export Content Ordering & Summarization
+
+## Problem Statement
+
+When a user downloads a PPTX from a presentation artifact, two critical bugs degrade the output:
+
+1. **Scrambled content ordering**: Slide body content appears grouped by *type* (all body paragraphs first, then all bullets) rather than in the *original document order* the author wrote. This means titles/headers appear bunched together before content, making it impossible to relate a header to its corresponding content.
+
+2. **Lossy AI summarization**: The AI optimization step was discarding information rather than properly condensing it. Key content that didn't fit into the tight AI summary was simply lost — not even saved to speaker notes. This defeats the purpose of the summarization.
+
+## Target User
+
+Product managers, researchers, and analysts who create presentation artifacts from research documents and need to export them as PPTX for sharing or presenting.
+
+## Success Metrics
+
+- Speaker notes contain **all** original content in **document reading order**
+- Slide bodies show a clean 3-4 bullet summary without losing information
+- No content is lost: every key point from the source document is findable in the notes
+
+## User Stories
+
+1. **As a user**, I want slide speaker notes to appear in the same order as my document so I can read along while presenting.
+2. **As a user**, I want each content-heavy slide to show a concise 3-4 bullet summary on screen while keeping full details in the notes.
+3. **As a user**, I don't want any of my content to disappear during export — everything should be preserved somewhere.
+
+## Scope
+
+**In scope:**
+- Fix `parseMarkdownToSlides` to build ordered speaker notes during line traversal
+- Fix the fallback and AI export paths in `MarkdownEditor.tsx` to use those ordered notes
+- Revise the AI prompt to request layout + summary only (not restructure content)
+- Add automated tests verifying note ordering
+
+**Out of scope:**
+- Visual slide design changes
+- New layout types
+- Changing the markdown format expected by the parser
+
+## Acceptance Criteria
+
+- [ ] Speaker notes show content in document order (intro text before bullets, sub-bullets after their parent)
+- [ ] Explicit `**Speaker Notes:**` blocks still win over auto-built notes
+- [ ] The AI optimization step only returns layout hint + 3-4 summary bullets
+- [ ] No information from source document is lost (all content reachable via notes)
+- [ ] All 8 automated tests pass
+- [ ] Slide count matches markdown section count (no extra continuation slides)

--- a/docs/features/pptx-content-fix/prd.md
+++ b/docs/features/pptx-content-fix/prd.md
@@ -31,10 +31,10 @@ Product managers, researchers, and analysts who create presentation artifacts fr
 - Fix the fallback and AI export paths in `MarkdownEditor.tsx` to use those ordered notes
 - Revise the AI prompt to request layout + summary only (not restructure content)
 - Add automated tests verifying note ordering
+- Implement and support the new `spotlight` layout (metric / key statistic focus) in the parsing and export flow
 
 **Out of scope:**
 - Visual slide design changes
-- New layout types
 - Changing the markdown format expected by the parser
 
 ## Acceptance Criteria

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "webdriverio": "9.27.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -15105,9 +15105,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15666,9 +15666,9 @@
       }
     },
     "node_modules/webdriver/node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/components/workspace/MarkdownEditor.tsx
+++ b/src/components/workspace/MarkdownEditor.tsx
@@ -52,13 +52,13 @@ function AIProgressToast() {
   const spinner = spinnerChars[spinnerFrame];
 
   const PM_STEPS = [
-    { label: "Aligning on 'North Star' vision", minProgress: 0 },
-    { label: "Prioritizing via random RICE scoring", minProgress: 15 },
-    { label: "Maximizing AI buzzword density", minProgress: 35 },
-    { label: "Optimizing layouts for the HIPPO", minProgress: 55 },
-    { label: "Reframing bugs as 'future roadmap'", minProgress: 75 },
-    { label: "Adding decorative upward growth arrows", minProgress: 90 },
-    { label: "Renaming to Presentation_FINAL_v2.pptx", minProgress: 96 }
+    { label: "Analyzing slide structure", minProgress: 0 },
+    { label: "Prioritizing key takeaways", minProgress: 15 },
+    { label: "Optimizing visual hierarchy", minProgress: 35 },
+    { label: "Selecting slide layouts", minProgress: 55 },
+    { label: "Preserving speaker notes", minProgress: 75 },
+    { label: "Applying brand styling", minProgress: 90 },
+    { label: "Finalizing PPTX export", minProgress: 96 }
   ];
 
   return (
@@ -75,7 +75,7 @@ function AIProgressToast() {
       </div>
       <div className="h-2 w-full bg-secondary/60 rounded-full overflow-hidden p-[1px] border border-border/10 shadow-inner">
         <div 
-          className="h-full bg-gradient-to-r from-primary/80 to-primary rounded-full transition-all duration-300 ease-out shadow-[0_0_8px_rgba(var(--primary),0.4)]" 
+          className="h-full bg-gradient-to-r from-primary/80 to-primary rounded-full transition-all duration-300 ease-out shadow-[0_0_8px_hsl(var(--primary)/0.4)]" 
           style={{ width: `${progress}%` }} 
         />
       </div>
@@ -95,14 +95,14 @@ function AIProgressToast() {
             );
           } else if (isActive) {
             return (
-              <div key={idx} className="flex items-center gap-2 text-amber-400 dark:text-amber-300 font-semibold">
+              <div key={idx} className="flex items-center gap-2 text-amber-500 dark:text-amber-400 font-semibold">
                 <span className="text-[9px]">{spinner}</span>
                 <span>{step.label}...</span>
               </div>
             );
           } else {
             return (
-              <div key={idx} className="flex items-center gap-2 text-zinc-600 dark:text-zinc-700">
+              <div key={idx} className="flex items-center gap-2 text-muted-foreground/50">
                 <span className="text-[9px] font-bold">◦</span>
                 <span>{step.label}</span>
               </div>
@@ -776,14 +776,23 @@ Respond ONLY with a raw JSON array of exactly ${slideCount} objects. No markdown
 
                                 if (jsonSlides && jsonSlides.length > 0) {
                                   const aiSlides = parsedSections.map((originalSection, idx) => {
-                                    const aiSlide = jsonSlides!.find((s: any) => s && s.slideIndex === idx) || jsonSlides![idx];
+                                    const aiSlide =
+                                      jsonSlides!.find((s: any) => {
+                                        if (!s || s.slideIndex === undefined || s.slideIndex === null) return false;
+                                        const slideIndex = Number(s.slideIndex);
+                                        return Number.isInteger(slideIndex) && slideIndex === idx;
+                                      }) ||
+                                      (jsonSlides![idx] && (jsonSlides![idx].slideIndex === undefined || jsonSlides![idx].slideIndex === null)
+                                        ? jsonSlides![idx]
+                                        : null);
                                     if (!aiSlide) {
                                       // Fall back to the safe truncated version already set
                                       return (slidesDataToExport as any[])[idx];
                                     }
 
                                     const subBullets = new Map<number, string[]>();
-                                    (aiSlide.items || []).forEach((item: any, i: number) => {
+                                    const aiItems = Array.isArray(aiSlide.items) ? aiSlide.items : [];
+                                    aiItems.forEach((item: any, i: number) => {
                                       const bulletList = item.summaryBullets || item.bullets || item.summary || [];
                                       if (Array.isArray(bulletList)) {
                                         subBullets.set(i, bulletList);
@@ -805,11 +814,11 @@ Respond ONLY with a raw JSON array of exactly ${slideCount} objects. No markdown
                                         isGoal: t.toLowerCase().startsWith('goal:')
                                       });
                                     });
-                                    const parsedBullets = aiSlide.items
-                                      ? aiSlide.items.map((item: any) =>
+                                    const parsedBullets = aiItems.length > 0
+                                      ? aiItems.map((item: any) =>
                                           item.year ? `${item.year} - ${item.title || ''}` : (item.title || '')
                                         )
-                                      : (aiSlide.bullets || []);
+                                      : (Array.isArray(aiSlide.bullets) ? aiSlide.bullets : []);
                                     parsedBullets.forEach((b: string, idx: number) => {
                                       const subs = subBullets.get(idx) || [];
                                       aiElements.push({

--- a/src/components/workspace/MarkdownEditor.tsx
+++ b/src/components/workspace/MarkdownEditor.tsx
@@ -51,14 +51,15 @@ function AIProgressToast() {
   const spinnerChars = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
   const spinner = spinnerChars[spinnerFrame];
 
+  // Adding funny PM steps for the progress
   const PM_STEPS = [
-    { label: "Analyzing slide structure", minProgress: 0 },
-    { label: "Prioritizing key takeaways", minProgress: 15 },
-    { label: "Optimizing visual hierarchy", minProgress: 35 },
-    { label: "Selecting slide layouts", minProgress: 55 },
-    { label: "Preserving speaker notes", minProgress: 75 },
-    { label: "Applying brand styling", minProgress: 90 },
-    { label: "Finalizing PPTX export", minProgress: 96 }
+    { label: "Aligning on 'North Star' vision", minProgress: 0 },
+    { label: "Prioritizing via random RICE scoring", minProgress: 15 },
+    { label: "Maximizing AI buzzword density", minProgress: 35 },
+    { label: "Optimizing layouts for the HIPPO", minProgress: 55 },
+    { label: "Reframing bugs as 'future roadmap'", minProgress: 75 },
+    { label: "Adding decorative upward growth arrows", minProgress: 90 },
+    { label: "Renaming to Presentation_FINAL_v2.pptx", minProgress: 96 }
   ];
 
   return (

--- a/src/components/workspace/MarkdownEditor.tsx
+++ b/src/components/workspace/MarkdownEditor.tsx
@@ -575,21 +575,13 @@ ${selectedText}`;
                           console.error('Failed to parse JSON presentation content', err);
                         }
                       } else if (content.trim().length > 100) {
- // Step 1: Parse the markdown into its natural sections FIRST.
-                      // This is the authoritative slide count — same as "Edit Layout" uses.
-                      // parseMarkdownToSlides now builds speakerNotes in document order
-                      // (bodyText and bullets interleaved as written, not grouped separately).
                         const parsedSections = parseMarkdownToSlides(content);
                         const slideCount = parsedSections.length;
 
                         if (slideCount > 0) {
-                        // CRITICAL: Set a SAFE FALLBACK immediately before trying the AI.
-                        // Display shows first 4 bullets; all original content (in document order)
-                        // is already in s.speakerNotes from the parser — no re-assembly needed.
                           slidesDataToExport = parsedSections.map(s => ({
                             title: s.title,
                             layoutHint: s.layoutHint,
-                            // speakerNotes already contains full content in document order
                             speakerNotes: s.speakerNotes || '',
                             fullText: s.speakerNotes || '',
                             bullets: s.bullets.slice(0, 4),
@@ -599,18 +591,11 @@ ${selectedText}`;
                             startLine: s.startLine
                           }));
 
-                         // Step 2: If we have a project context, try AI optimization.
-                          // The AI's ONLY job is: pick the best layout + write 3-4 summary bullets.
-                          // It NEVER touches speaker notes — those always come from the original text.
                           if (projectId) {
                             try {
-                              // Send full ordered content so the AI can make good layout/summary decisions.
-                              // We do NOT need to cap per-slide content here because notes are assembled
-                              // independently — the AI response cannot overwrite them.
                               const sectionsForAI = parsedSections.map((s, i) => ({
                                 slideIndex: i,
                                 title: s.title,
-                                // Use the ordered notes text (bullets + body interleaved) as the source of truth
                                 content: s.speakerNotes || ''
                               }));
 
@@ -625,21 +610,26 @@ RULES (non-negotiable):
 2. Do NOT add, split, merge, or reorder slides.
 3. Do NOT return speakerNotes, fullText, or any original content — those are handled separately.
 4. For each slide output these fields only:
+   - "slideIndex": The integer index from the input. REQUIRED.
    - "title": Keep as-is or trim to ≤8 words. REQUIRED.
    - "layoutHint": Choose the BEST layout from: 'title', 'section', 'split', 'columns', 'comparison', 'timeline'. REQUIRED.
      • Use 'title' only for the first/cover slide.
      • Use 'section' for transition/divider slides with little content.
      • Use 'columns' when there are 3-4 independent parallel items (features, options, pillars).
-     • Use 'comparison' when exactly two things are being compared side-by-side.
+     • Use 'comparison' when exactly two things/lists are being compared side-by-side (e.g. Q3 vs Q4 features, Pros vs Cons).
      • Use 'timeline' when content contains chronological milestones or dated events.
      • Use 'split' (default) for most content slides with a clear title + supporting points.
-   - "bullets": Array of 3-4 concise summary strings (each ≤10 words). Capture the KEY takeaways only.
+   - "bullets": Array of 3-6 concise summary strings (each ≤10 words). Capture the KEY takeaways only.
      Use [] for 'section' or 'title' slides.
    - "bodyText": Array with at most 1 kicker sentence (≤15 words) — the single most important idea.
      Use [] for 'section', 'title', 'columns', 'comparison', or 'timeline' slides.
    - "items": ONLY for 'columns' layout: array of {title, summaryBullets[]} objects.
      ONLY for 'timeline' layout: array of {year, title, summary} objects.
      Omit this field for all other layouts.
+5. Every slide in the input is distinct and MUST be processed. Do not skip, drop, or merge slides, even if they have duplicate or similar titles.
+6. For the "items" field in 'columns' layout: group parallel bullet points under their respective header or category (e.g. if the slide contains multiple plain text headers/labels followed by bullets, create a column/item for each header where its title is the header text, and its summaryBullets are the bullets under it). Do not list bullets as separate column titles; group them. Include all relevant columns/groups present in the source (up to 6 columns).
+7. For the "items" field in 'timeline' layout: extract all milestones/events from the content (up to 6 items).
+8. For 'comparison' layout: use when comparing exactly two categories/lists (e.g. Q3 vs Q4, Pros vs Cons).
 
 Input:
 ${JSON.stringify(sectionsForAI, null, 2)}
@@ -653,7 +643,6 @@ Respond ONLY with a raw JSON array of exactly ${slideCount} objects. No markdown
 
                               if (response?.content) {
                                 let rawText = response.content.trim();
-                              // Robust JSON extraction: find outermost [ ... ]
                                 const startIdx = rawText.indexOf('[');
                                 const endIdx = rawText.lastIndexOf(']');
                                 if (startIdx !== -1 && endIdx > startIdx) {
@@ -673,9 +662,8 @@ Respond ONLY with a raw JSON array of exactly ${slideCount} objects. No markdown
                                 }
 
                                 if (jsonSlides && jsonSlides.length > 0) {
-                                  // Merge AI layout/summary decisions with original ordered notes.
                                   const aiSlides = parsedSections.map((originalSection, idx) => {
-                                    const aiSlide = jsonSlides![idx];
+                                    const aiSlide = jsonSlides!.find((s: any) => s && s.slideIndex === idx) || jsonSlides![idx];
                                     if (!aiSlide) {
                                       // Fall back to the safe truncated version already set
                                       return (slidesDataToExport as any[])[idx];
@@ -683,8 +671,11 @@ Respond ONLY with a raw JSON array of exactly ${slideCount} objects. No markdown
 
                                     const subBullets = new Map<number, string[]>();
                                     (aiSlide.items || []).forEach((item: any, i: number) => {
-                                      if (Array.isArray(item.summaryBullets)) {
-                                        subBullets.set(i, item.summaryBullets);
+                                      const bulletList = item.summaryBullets || item.bullets || item.summary || [];
+                                      if (Array.isArray(bulletList)) {
+                                        subBullets.set(i, bulletList);
+                                      } else if (typeof bulletList === 'string') {
+                                        subBullets.set(i, [bulletList]);
                                       }
                                     });
 

--- a/src/components/workspace/MarkdownEditor.tsx
+++ b/src/components/workspace/MarkdownEditor.tsx
@@ -17,6 +17,51 @@ import { ConfidenceBars } from './ConfidenceBars';
 
 const scrollPositions = new Map<string, number>();
 
+function AIProgressToast() {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const start = Date.now();
+    const duration = 22000; // Estimated duration for AI optimization
+    const interval = setInterval(() => {
+      const elapsed = Date.now() - start;
+      let nextProgress;
+      if (elapsed < duration) {
+        nextProgress = Math.round((elapsed / duration) * 88);
+      } else if (elapsed < duration * 2) {
+        const extraTime = elapsed - duration;
+        nextProgress = 88 + Math.round((extraTime / duration) * 8);
+      } else {
+        nextProgress = 96 + Math.min(2, Math.floor((elapsed - duration * 2) / 6000));
+      }
+      setProgress(Math.min(98, nextProgress));
+    }, 200);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-2.5 w-full min-w-[280px] mt-2">
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span className="flex items-center gap-1.5 font-medium">
+          <span className="relative flex h-2 w-2">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75"></span>
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-primary"></span>
+          </span>
+          Optimizing layouts & pacing...
+        </span>
+        <span className="font-mono font-bold text-primary">{progress}%</span>
+      </div>
+      <div className="h-2 w-full bg-secondary/60 rounded-full overflow-hidden p-[1px] border border-border/10 shadow-inner">
+        <div 
+          className="h-full bg-gradient-to-r from-primary/80 to-primary rounded-full transition-all duration-300 ease-out shadow-[0_0_8px_rgba(var(--primary),0.4)]" 
+          style={{ width: `${progress}%` }} 
+        />
+      </div>
+    </div>
+  );
+}
+
 interface MarkdownEditorProps {
   activeDoc: {
     id: string;
@@ -506,65 +551,70 @@ ${selectedText}`;
                       }
                     }
 
-                    toast({ title: 'Preparing PPTX', description: 'AI is optimizing slide layouts & pacing...' });
+                    const progressToast = toast({
+                      title: 'Preparing PPTX',
+                      description: <AIProgressToast />,
+                      duration: 999999,
+                    });
                     
-                    let slidesDataToExport: any = content;
-                    const isJsonFile = activeDoc.name?.toLowerCase().endsWith('.json');
+                    try {
+                      let slidesDataToExport: any = content;
+                      const isJsonFile = activeDoc.name?.toLowerCase().endsWith('.json');
 
-                    if (isJsonFile) {
-                      try {
-                        const parsed = JSON.parse(content);
-                        if (Array.isArray(parsed)) {
-                          slidesDataToExport = parsed;
-                        } else if (parsed && typeof parsed === 'object' && Array.isArray(parsed.slides)) {
-                          slidesDataToExport = parsed.slides;
-                        } else if (parsed) {
-                          slidesDataToExport = [parsed];
+                      if (isJsonFile) {
+                        try {
+                          const parsed = JSON.parse(content);
+                          if (Array.isArray(parsed)) {
+                            slidesDataToExport = parsed;
+                          } else if (parsed && typeof parsed === 'object' && Array.isArray(parsed.slides)) {
+                            slidesDataToExport = parsed.slides;
+                          } else if (parsed) {
+                            slidesDataToExport = [parsed];
+                          }
+                        } catch (err) {
+                          console.error('Failed to parse JSON presentation content', err);
                         }
-                      } catch (err) {
-                        console.error('Failed to parse JSON presentation content', err);
-                      }
-                    } else if (content.trim().length > 100) {
-                      // Step 1: Parse the markdown into its natural sections FIRST.
+                      } else if (content.trim().length > 100) {
+ // Step 1: Parse the markdown into its natural sections FIRST.
                       // This is the authoritative slide count — same as "Edit Layout" uses.
                       // parseMarkdownToSlides now builds speakerNotes in document order
                       // (bodyText and bullets interleaved as written, not grouped separately).
-                      const parsedSections = parseMarkdownToSlides(content);
-                      const slideCount = parsedSections.length;
+                        const parsedSections = parseMarkdownToSlides(content);
+                        const slideCount = parsedSections.length;
 
-                      if (slideCount > 0) {
+                        if (slideCount > 0) {
                         // CRITICAL: Set a SAFE FALLBACK immediately before trying the AI.
                         // Display shows first 4 bullets; all original content (in document order)
                         // is already in s.speakerNotes from the parser — no re-assembly needed.
-                        slidesDataToExport = parsedSections.map(s => ({
-                          title: s.title,
-                          layoutHint: s.layoutHint,
-                          // speakerNotes already contains full content in document order
-                          speakerNotes: s.speakerNotes || '',
-                          fullText: s.speakerNotes || '',
-                          bullets: s.bullets.slice(0, 4),
-                          subBullets: s.subBullets,
-                          bodyText: s.bodyText.slice(0, 2),
-                          items: [],
-                          startLine: s.startLine
-                        }));
+                          slidesDataToExport = parsedSections.map(s => ({
+                            title: s.title,
+                            layoutHint: s.layoutHint,
+                            // speakerNotes already contains full content in document order
+                            speakerNotes: s.speakerNotes || '',
+                            fullText: s.speakerNotes || '',
+                            bullets: s.bullets.slice(0, 4),
+                            subBullets: s.subBullets,
+                            bodyText: s.bodyText.slice(0, 2),
+                            items: [],
+                            startLine: s.startLine
+                          }));
 
-                        // Step 2: If we have a project context, try AI optimization.
-                        // The AI's ONLY job is: pick the best layout + write 3-4 summary bullets.
-                        // It NEVER touches speaker notes — those always come from the original text.
-                        if (projectId) {
-                          try {
-                            // Send full ordered content so the AI can make good layout/summary decisions.
-                            // We do NOT need to cap per-slide content here because notes are assembled
-                            // independently — the AI response cannot overwrite them.
-                            const sectionsForAI = parsedSections.map((s, i) => ({
-                              slideIndex: i,
-                              title: s.title,
-                              // Use the ordered notes text (bullets + body interleaved) as the source of truth
-                              content: s.speakerNotes || ''
-                            }));
+                         // Step 2: If we have a project context, try AI optimization.
+                          // The AI's ONLY job is: pick the best layout + write 3-4 summary bullets.
+                          // It NEVER touches speaker notes — those always come from the original text.
+                          if (projectId) {
+                            try {
+                              // Send full ordered content so the AI can make good layout/summary decisions.
+                              // We do NOT need to cap per-slide content here because notes are assembled
+                              // independently — the AI response cannot overwrite them.
+                              const sectionsForAI = parsedSections.map((s, i) => ({
+                                slideIndex: i,
+                                title: s.title,
+                                // Use the ordered notes text (bullets + body interleaved) as the source of truth
+                                content: s.speakerNotes || ''
+                              }));
 
-                            const promptContext = `You are an expert presentation designer.
+                              const promptContext = `You are an expert presentation designer.
 You are given ${slideCount} slides extracted from a presentation document.
 
 TASK: For each slide, choose the best visual layout and write a SHORT on-slide summary.
@@ -596,69 +646,69 @@ ${JSON.stringify(sectionsForAI, null, 2)}
 
 Respond ONLY with a raw JSON array of exactly ${slideCount} objects. No markdown fences, no explanation.`;
 
-                            const response = await appApi.sendMessage(
-                              [{ role: 'user', content: promptContext }],
-                              projectId
-                            );
+                              const response = await appApi.sendMessage(
+                                [{ role: 'user', content: promptContext }],
+                                projectId
+                              );
 
-                            if (response?.content) {
-                              let rawText = response.content.trim();
+                              if (response?.content) {
+                                let rawText = response.content.trim();
                               // Robust JSON extraction: find outermost [ ... ]
-                              const startIdx = rawText.indexOf('[');
-                              const endIdx = rawText.lastIndexOf(']');
-                              if (startIdx !== -1 && endIdx > startIdx) {
-                                rawText = rawText.substring(startIdx, endIdx + 1);
-                              } else if (rawText.startsWith('```')) {
-                                rawText = rawText.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
-                              }
-
-                              let jsonSlides: any[] | null = null;
-                              try {
-                                const parsed = JSON.parse(rawText);
-                                if (Array.isArray(parsed) && parsed.length > 0) {
-                                  jsonSlides = parsed;
+                                const startIdx = rawText.indexOf('[');
+                                const endIdx = rawText.lastIndexOf(']');
+                                if (startIdx !== -1 && endIdx > startIdx) {
+                                  rawText = rawText.substring(startIdx, endIdx + 1);
+                                } else if (rawText.startsWith('```')) {
+                                  rawText = rawText.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
                                 }
-                              } catch (parseErr) {
-                                console.warn('AI pipeline: JSON.parse failed, using fallback', parseErr);
-                              }
 
-                              if (jsonSlides && jsonSlides.length > 0) {
-                                // Merge AI layout/summary decisions with original ordered notes.
-                                const aiSlides = parsedSections.map((originalSection, idx) => {
-                                  const aiSlide = jsonSlides![idx];
-                                  if (!aiSlide) {
-                                    // Fall back to the safe truncated version already set
-                                    return (slidesDataToExport as any[])[idx];
+                                let jsonSlides: any[] | null = null;
+                                try {
+                                  const parsed = JSON.parse(rawText);
+                                  if (Array.isArray(parsed) && parsed.length > 0) {
+                                    jsonSlides = parsed;
                                   }
+                                } catch (parseErr) {
+                                  console.warn('AI pipeline: JSON.parse failed, using fallback', parseErr);
+                                }
 
-                                  const subBullets = new Map<number, string[]>();
-                                  (aiSlide.items || []).forEach((item: any, i: number) => {
-                                    if (Array.isArray(item.summaryBullets)) {
-                                      subBullets.set(i, item.summaryBullets);
+                                if (jsonSlides && jsonSlides.length > 0) {
+                                  // Merge AI layout/summary decisions with original ordered notes.
+                                  const aiSlides = parsedSections.map((originalSection, idx) => {
+                                    const aiSlide = jsonSlides![idx];
+                                    if (!aiSlide) {
+                                      // Fall back to the safe truncated version already set
+                                      return (slidesDataToExport as any[])[idx];
                                     }
+
+                                    const subBullets = new Map<number, string[]>();
+                                    (aiSlide.items || []).forEach((item: any, i: number) => {
+                                      if (Array.isArray(item.summaryBullets)) {
+                                        subBullets.set(i, item.summaryBullets);
+                                      }
+                                    });
+
+                                    // ALWAYS use the parser-built ordered notes — never the AI output.
+                                    // This guarantees full content in document order is preserved.
+                                    const orderedNotes = originalSection.speakerNotes || '';
+
+                                    return {
+                                      title: aiSlide.title || originalSection.title,
+                                      layoutHint: aiSlide.layoutHint || 'split',
+                                      // Notes come from the original document, not the AI
+                                      speakerNotes: orderedNotes,
+                                      fullText: orderedNotes,
+                                      bullets: aiSlide.items
+                                        ? aiSlide.items.map((item: any) =>
+                                            item.year ? `${item.year} - ${item.title || ''}` : (item.title || '')
+                                          )
+                                        : (aiSlide.bullets || []),
+                                      subBullets,
+                                      bodyText: aiSlide.bodyText || [],
+                                      items: aiSlide.items || [],
+                                      startLine: originalSection.startLine
+                                    };
                                   });
-
-                                  // ALWAYS use the parser-built ordered notes — never the AI output.
-                                  // This guarantees full content in document order is preserved.
-                                  const orderedNotes = originalSection.speakerNotes || '';
-
-                                  return {
-                                    title: aiSlide.title || originalSection.title,
-                                    layoutHint: aiSlide.layoutHint || 'split',
-                                    // Notes come from the original document, not the AI
-                                    speakerNotes: orderedNotes,
-                                    fullText: orderedNotes,
-                                    bullets: aiSlide.items
-                                      ? aiSlide.items.map((item: any) =>
-                                          item.year ? `${item.year} - ${item.title || ''}` : (item.title || '')
-                                        )
-                                      : (aiSlide.bullets || []),
-                                    subBullets,
-                                    bodyText: aiSlide.bodyText || [],
-                                    items: aiSlide.items || [],
-                                    startLine: originalSection.startLine
-                                  };
-                                });
 
                                 slidesDataToExport = aiSlides;
                               } else {
@@ -681,14 +731,21 @@ Respond ONLY with a raw JSON array of exactly ${slideCount} objects. No markdown
                     }
 
 
-                    const result = await exportToPptx(slidesDataToExport, brandSettings, (activeDoc.name || activeDoc.id).replace('.md', ''));
-                    if (result.success) {
-                      const msg = result.defaultUsed 
-                        ? 'Downloaded successfully using default brand settings.' 
-                        : 'Downloaded successfully using project brand settings.';
-                      toast({ title: 'PPTX Export Successful', description: msg });
-                    } else {
-                      toast({ title: 'PPTX Export Failed', description: String(result.error), variant: 'destructive' });
+                      const result = await exportToPptx(slidesDataToExport, brandSettings, (activeDoc.name || activeDoc.id).replace('.md', ''));
+                      progressToast.dismiss();
+
+                      if (result.success) {
+                        const msg = result.defaultUsed 
+                          ? 'Downloaded successfully using default brand settings.' 
+                          : 'Downloaded successfully using project brand settings.';
+                        toast({ title: 'PPTX Export Successful', description: msg });
+                      } else {
+                        toast({ title: 'PPTX Export Failed', description: String(result.error), variant: 'destructive' });
+                      }
+                    } catch (error) {
+                      progressToast.dismiss();
+                      console.error('PPTX export error:', error);
+                      toast({ title: 'PPTX Export Failed', description: String(error), variant: 'destructive' });
                     }
                   }}
                   className="h-8 gap-2 rounded border border-border bg-background hover:bg-muted text-foreground whitespace-nowrap"

--- a/src/components/workspace/MarkdownEditor.tsx
+++ b/src/components/workspace/MarkdownEditor.tsx
@@ -527,65 +527,69 @@ ${selectedText}`;
                     } else if (content.trim().length > 100) {
                       // Step 1: Parse the markdown into its natural sections FIRST.
                       // This is the authoritative slide count — same as "Edit Layout" uses.
+                      // parseMarkdownToSlides now builds speakerNotes in document order
+                      // (bodyText and bullets interleaved as written, not grouped separately).
                       const parsedSections = parseMarkdownToSlides(content);
                       const slideCount = parsedSections.length;
 
                       if (slideCount > 0) {
                         // CRITICAL: Set a SAFE FALLBACK immediately before trying the AI.
-                        // Truncate display content to prevent overflow continuation slides.
-                        // Full content always goes to speakerNotes.
-                        slidesDataToExport = parsedSections.map(s => {
-                          const allText = [
-                            ...s.bodyText,
-                            ...s.bullets,
-                            ...Array.from(s.subBullets.values()).flat()
-                          ].join('\n');
-                          return {
-                            title: s.title,
-                            layoutHint: s.layoutHint,
-                            speakerNotes: allText,
-                            fullText: allText,
-                            bullets: s.bullets.slice(0, 4),
-                            subBullets: s.subBullets,
-                            bodyText: s.bodyText.slice(0, 2),
-                            items: [],
-                            startLine: s.startLine
-                          };
-                        });
+                        // Display shows first 4 bullets; all original content (in document order)
+                        // is already in s.speakerNotes from the parser — no re-assembly needed.
+                        slidesDataToExport = parsedSections.map(s => ({
+                          title: s.title,
+                          layoutHint: s.layoutHint,
+                          // speakerNotes already contains full content in document order
+                          speakerNotes: s.speakerNotes || '',
+                          fullText: s.speakerNotes || '',
+                          bullets: s.bullets.slice(0, 4),
+                          subBullets: s.subBullets,
+                          bodyText: s.bodyText.slice(0, 2),
+                          items: [],
+                          startLine: s.startLine
+                        }));
 
                         // Step 2: If we have a project context, try AI optimization.
-                        // If it fails for any reason, the safe truncated fallback is already set.
+                        // The AI's ONLY job is: pick the best layout + write 3-4 summary bullets.
+                        // It NEVER touches speaker notes — those always come from the original text.
                         if (projectId) {
                           try {
-                            // Cap rawContent per section — AI only needs the gist.
-                            // Sending the full document causes the AI to echo it back as fullText,
-                            // which then overflows into 60+ continuation slides.
-                            const MAX_CONTENT_CHARS = 800;
+                            // Send full ordered content so the AI can make good layout/summary decisions.
+                            // We do NOT need to cap per-slide content here because notes are assembled
+                            // independently — the AI response cannot overwrite them.
                             const sectionsForAI = parsedSections.map((s, i) => ({
                               slideIndex: i,
                               title: s.title,
-                              rawContent: [
-                                ...s.bodyText,
-                                ...s.bullets,
-                                ...Array.from(s.subBullets.values()).flat()
-                              ].join(' | ').slice(0, MAX_CONTENT_CHARS)
+                              // Use the ordered notes text (bullets + body interleaved) as the source of truth
+                              content: s.speakerNotes || ''
                             }));
 
                             const promptContext = `You are an expert presentation designer.
 You are given ${slideCount} slides extracted from a presentation document.
-Each has a title and a content snippet (may be truncated).
 
-TASK: Optimize each slide for a professional slide deck.
+TASK: For each slide, choose the best visual layout and write a SHORT on-slide summary.
+The full content will always be preserved in speaker notes separately — do NOT include it in your response.
 
 RULES (non-negotiable):
-1. Return EXACTLY ${slideCount} JSON objects — same order, one per input slide.
-2. Do NOT add, split, or merge slides.
-3. For each slide output:
-   - "title": Keep as-is or shorten slightly. REQUIRED.
-   - "layoutHint": Best layout from: 'title', 'section', 'split', 'columns', 'comparison', 'timeline'. REQUIRED.
-   - "bodyText": Array with ONE sentence max 12 words — the key insight. Use [] for 'section'/'title'.
-   - "bullets": Max 3 strings each ≤8 words. Use [] for 'section'/'title'.
-   - "items": Only for 'columns' ({title, summaryBullets[]}) or 'timeline' ({year, title, summary}). Omit otherwise.
+1. Return EXACTLY ${slideCount} JSON objects in the same order as input.
+2. Do NOT add, split, merge, or reorder slides.
+3. Do NOT return speakerNotes, fullText, or any original content — those are handled separately.
+4. For each slide output these fields only:
+   - "title": Keep as-is or trim to ≤8 words. REQUIRED.
+   - "layoutHint": Choose the BEST layout from: 'title', 'section', 'split', 'columns', 'comparison', 'timeline'. REQUIRED.
+     • Use 'title' only for the first/cover slide.
+     • Use 'section' for transition/divider slides with little content.
+     • Use 'columns' when there are 3-4 independent parallel items (features, options, pillars).
+     • Use 'comparison' when exactly two things are being compared side-by-side.
+     • Use 'timeline' when content contains chronological milestones or dated events.
+     • Use 'split' (default) for most content slides with a clear title + supporting points.
+   - "bullets": Array of 3-4 concise summary strings (each ≤10 words). Capture the KEY takeaways only.
+     Use [] for 'section' or 'title' slides.
+   - "bodyText": Array with at most 1 kicker sentence (≤15 words) — the single most important idea.
+     Use [] for 'section', 'title', 'columns', 'comparison', or 'timeline' slides.
+   - "items": ONLY for 'columns' layout: array of {title, summaryBullets[]} objects.
+     ONLY for 'timeline' layout: array of {year, title, summary} objects.
+     Omit this field for all other layouts.
 
 Input:
 ${JSON.stringify(sectionsForAI, null, 2)}
@@ -619,11 +623,12 @@ Respond ONLY with a raw JSON array of exactly ${slideCount} objects. No markdown
                               }
 
                               if (jsonSlides && jsonSlides.length > 0) {
-                                // Map AI output back to SlideData objects.
+                                // Merge AI layout/summary decisions with original ordered notes.
                                 const aiSlides = parsedSections.map((originalSection, idx) => {
                                   const aiSlide = jsonSlides![idx];
                                   if (!aiSlide) {
-                                    return (slidesDataToExport as any[])[idx]; // truncated fallback
+                                    // Fall back to the safe truncated version already set
+                                    return (slidesDataToExport as any[])[idx];
                                   }
 
                                   const subBullets = new Map<number, string[]>();
@@ -633,18 +638,16 @@ Respond ONLY with a raw JSON array of exactly ${slideCount} objects. No markdown
                                     }
                                   });
 
-                                  // ALWAYS use full original content for speaker notes
-                                  const originalContent = [
-                                    ...originalSection.bodyText,
-                                    ...originalSection.bullets,
-                                    ...Array.from(originalSection.subBullets.values()).flat()
-                                  ].join('\n');
+                                  // ALWAYS use the parser-built ordered notes — never the AI output.
+                                  // This guarantees full content in document order is preserved.
+                                  const orderedNotes = originalSection.speakerNotes || '';
 
                                   return {
                                     title: aiSlide.title || originalSection.title,
                                     layoutHint: aiSlide.layoutHint || 'split',
-                                    speakerNotes: originalContent,
-                                    fullText: originalContent,
+                                    // Notes come from the original document, not the AI
+                                    speakerNotes: orderedNotes,
+                                    fullText: orderedNotes,
                                     bullets: aiSlide.items
                                       ? aiSlide.items.map((item: any) =>
                                           item.year ? `${item.year} - ${item.title || ''}` : (item.title || '')
@@ -676,6 +679,7 @@ Respond ONLY with a raw JSON array of exactly ${slideCount} objects. No markdown
                       }
                       // (if slideCount === 0, slidesDataToExport stays as content string)
                     }
+
 
                     const result = await exportToPptx(slidesDataToExport, brandSettings, (activeDoc.name || activeDoc.id).replace('.md', ''));
                     if (result.success) {

--- a/src/components/workspace/MarkdownEditor.tsx
+++ b/src/components/workspace/MarkdownEditor.tsx
@@ -19,6 +19,7 @@ const scrollPositions = new Map<string, number>();
 
 function AIProgressToast() {
   const [progress, setProgress] = useState(0);
+  const [spinnerFrame, setSpinnerFrame] = useState(0);
 
   useEffect(() => {
     const start = Date.now();
@@ -40,6 +41,26 @@ function AIProgressToast() {
     return () => clearInterval(interval);
   }, []);
 
+  useEffect(() => {
+    const spinInterval = setInterval(() => {
+      setSpinnerFrame(f => (f + 1) % 10);
+    }, 150);
+    return () => clearInterval(spinInterval);
+  }, []);
+
+  const spinnerChars = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+  const spinner = spinnerChars[spinnerFrame];
+
+  const PM_STEPS = [
+    { label: "Aligning on 'North Star' vision", minProgress: 0 },
+    { label: "Prioritizing via random RICE scoring", minProgress: 15 },
+    { label: "Maximizing AI buzzword density", minProgress: 35 },
+    { label: "Optimizing layouts for the HIPPO", minProgress: 55 },
+    { label: "Reframing bugs as 'future roadmap'", minProgress: 75 },
+    { label: "Adding decorative upward growth arrows", minProgress: 90 },
+    { label: "Renaming to Presentation_FINAL_v2.pptx", minProgress: 96 }
+  ];
+
   return (
     <div className="flex flex-col gap-2.5 w-full min-w-[280px] mt-2">
       <div className="flex items-center justify-between text-xs text-muted-foreground">
@@ -57,6 +78,37 @@ function AIProgressToast() {
           className="h-full bg-gradient-to-r from-primary/80 to-primary rounded-full transition-all duration-300 ease-out shadow-[0_0_8px_rgba(var(--primary),0.4)]" 
           style={{ width: `${progress}%` }} 
         />
+      </div>
+
+      {/* Claude Code style thinking terminal */}
+      <div className="mt-1 p-2.5 rounded border border-border/40 bg-zinc-950/90 dark:bg-black/60 font-mono text-[10px] text-zinc-300 leading-normal shadow-inner flex flex-col gap-1">
+        {PM_STEPS.map((step, idx) => {
+          const isDone = progress >= (PM_STEPS[idx + 1]?.minProgress ?? 101);
+          const isActive = progress >= step.minProgress && !isDone;
+
+          if (isDone) {
+            return (
+              <div key={idx} className="flex items-center gap-2 text-emerald-500/80 dark:text-emerald-400/80">
+                <span className="text-[9px] font-bold">✔</span>
+                <span className="line-through opacity-70">{step.label}</span>
+              </div>
+            );
+          } else if (isActive) {
+            return (
+              <div key={idx} className="flex items-center gap-2 text-amber-400 dark:text-amber-300 font-semibold">
+                <span className="text-[9px]">{spinner}</span>
+                <span>{step.label}...</span>
+              </div>
+            );
+          } else {
+            return (
+              <div key={idx} className="flex items-center gap-2 text-zinc-600 dark:text-zinc-700">
+                <span className="text-[9px] font-bold">◦</span>
+                <span>{step.label}</span>
+              </div>
+            );
+          }
+        })}
       </div>
     </div>
   );

--- a/src/components/workspace/MarkdownEditor.tsx
+++ b/src/components/workspace/MarkdownEditor.tsx
@@ -636,10 +636,11 @@ ${selectedText}`;
                             layoutHint: s.layoutHint,
                             speakerNotes: s.speakerNotes || '',
                             fullText: s.speakerNotes || '',
-                            bullets: s.bullets.slice(0, 4),
+                            bullets: s.bullets,
                             subBullets: s.subBullets,
-                            bodyText: s.bodyText.slice(0, 2),
-                            items: [],
+                            bodyText: s.bodyText,
+                            items: s.items || [],
+                            elements: s.elements || [],
                             startLine: s.startLine
                           }));
 
@@ -682,6 +683,7 @@ RULES (non-negotiable):
 6. For the "items" field in 'columns' layout: group parallel bullet points under their respective header or category (e.g. if the slide contains multiple plain text headers/labels followed by bullets, create a column/item for each header where its title is the header text, and its summaryBullets are the bullets under it). Do not list bullets as separate column titles; group them. Include all relevant columns/groups present in the source (up to 6 columns).
 7. For the "items" field in 'timeline' layout: extract all milestones/events from the content (up to 6 items).
 8. For 'comparison' layout: use when comparing exactly two categories/lists (e.g. Q3 vs Q4, Pros vs Cons).
+9. Do NOT omit any distinct header, section, or category present in the slide content. If a slide contains multiple groups or headers (e.g. "Why This Matters:" or distinct labels), ensure every group is represented in the output (either as columns in 'columns' layout, or as separate bullet lists in 'split'/'standard' layout).
 
 Input:
 ${JSON.stringify(sectionsForAI, null, 2)}
@@ -735,20 +737,41 @@ Respond ONLY with a raw JSON array of exactly ${slideCount} objects. No markdown
                                     // This guarantees full content in document order is preserved.
                                     const orderedNotes = originalSection.speakerNotes || '';
 
+                                    const aiElements: any[] = [];
+                                    (aiSlide.bodyText || []).forEach((t: string) => {
+                                      aiElements.push({
+                                        type: 'paragraph',
+                                        text: t,
+                                        isLabel: t.includes(':') && t.length < 60,
+                                        isGoal: t.toLowerCase().startsWith('goal:')
+                                      });
+                                    });
+                                    const parsedBullets = aiSlide.items
+                                      ? aiSlide.items.map((item: any) =>
+                                          item.year ? `${item.year} - ${item.title || ''}` : (item.title || '')
+                                        )
+                                      : (aiSlide.bullets || []);
+                                    parsedBullets.forEach((b: string, idx: number) => {
+                                      const subs = subBullets.get(idx) || [];
+                                      aiElements.push({
+                                        type: 'bullet',
+                                        text: b,
+                                        indentLevel: 0,
+                                        subBullets: subs
+                                      });
+                                    });
+
                                     return {
                                       title: aiSlide.title || originalSection.title,
                                       layoutHint: aiSlide.layoutHint || 'split',
                                       // Notes come from the original document, not the AI
                                       speakerNotes: orderedNotes,
                                       fullText: orderedNotes,
-                                      bullets: aiSlide.items
-                                        ? aiSlide.items.map((item: any) =>
-                                            item.year ? `${item.year} - ${item.title || ''}` : (item.title || '')
-                                          )
-                                        : (aiSlide.bullets || []),
+                                      bullets: parsedBullets,
                                       subBullets,
                                       bodyText: aiSlide.bodyText || [],
                                       items: aiSlide.items || [],
+                                      elements: aiElements,
                                       startLine: originalSection.startLine
                                     };
                                   });

--- a/src/components/workspace/MarkdownEditor.tsx
+++ b/src/components/workspace/MarkdownEditor.tsx
@@ -652,10 +652,67 @@ ${selectedText}`;
                                 content: s.speakerNotes || ''
                               }));
 
-                              const promptContext = `You are an expert presentation designer.
+                              // Style auto-detection based on presentation name or content keywords
+                              const titleText = (activeDoc.name || activeDoc.id || "").toLowerCase();
+                              const firstSlideTitle = parsedSections[0]?.title?.toLowerCase() || "";
+                              const fullContentLower = content.toLowerCase();
+
+                              let styleInstruction = "Style: Professional business style. Clean layouts, structured bullets, clear hierarchy.";
+
+                              if (
+                                titleText.includes("executive") ||
+                                firstSlideTitle.includes("executive") ||
+                                fullContentLower.includes("executive summary")
+                              ) {
+                                styleInstruction = "Style: Executive summary deck - minimalist style, large visuals, max 3 bullets per slide, story-driven narrative, McKinsey-level polish.";
+                              } else if (
+                                titleText.includes("pitch") ||
+                                titleText.includes("vc") ||
+                                titleText.includes("investor") ||
+                                titleText.includes("funding") ||
+                                firstSlideTitle.includes("pitch") ||
+                                fullContentLower.includes("venture capital") ||
+                                fullContentLower.includes("investor pitch")
+                              ) {
+                                styleInstruction = "Style: Create a venture capital pitch style deck - very clean, high-contrast, big numbers, memorable visuals, strong problem-solution-investment ask arc.";
+                              } else if (
+                                titleText.includes("technical") ||
+                                titleText.includes("r&d") ||
+                                titleText.includes("developer") ||
+                                titleText.includes("architecture") ||
+                                titleText.includes("engineering") ||
+                                titleText.includes("code") ||
+                                fullContentLower.includes("technical architecture") ||
+                                fullContentLower.includes("engineering roadmap")
+                              ) {
+                                styleInstruction = "Style: Technical / R&D / Dev style - elegant, data-heavy but readable, with structured layouts suitable for architectural diagrams/flows.";
+                              } else if (
+                                titleText.includes("conference") ||
+                                titleText.includes("keynote") ||
+                                titleText.includes("customer") ||
+                                titleText.includes("external") ||
+                                titleText.includes("client") ||
+                                titleText.includes("public") ||
+                                firstSlideTitle.includes("conference") ||
+                                fullContentLower.includes("external presentation")
+                              ) {
+                                styleInstruction = "Style: Conference or customer-facing (external) style - high visual impact, bold headers, clear statements, story-driven narrative.";
+                              }
+
+                              const promptContext = `Act as a senior presentation designer who has worked at McKinsey / Apple / top VC pitch deck creators.
 You are given ${slideCount} slides extracted from a presentation document.
 
-TASK: For each slide, choose the best visual layout and write a SHORT on-slide summary.
+DESIGN DIRECTIVE:
+${styleInstruction}
+
+Follow modern best practices:
+- 10/20/30 rule awareness (but adapt to content)
+- Slide slogan technique: Title = main message/takeaway, not just a generic label (e.g., "Revenue Grew by 40%" instead of "Financial Results").
+- Visual metaphor when appropriate
+- High signal-to-noise ratio
+- Eliminate bullet-point crime: use punchy, impact-driven sentences, never generic walls of text.
+
+TASK: For each slide, choose the best visual layout, write a SHORT on-slide summary, and define visual layout attributes.
 The full content will always be preserved in speaker notes separately — do NOT include it in your response.
 
 RULES (non-negotiable):
@@ -664,26 +721,28 @@ RULES (non-negotiable):
 3. Do NOT return speakerNotes, fullText, or any original content — those are handled separately.
 4. For each slide output these fields only:
    - "slideIndex": The integer index from the input. REQUIRED.
-   - "title": Keep as-is or trim to ≤8 words. REQUIRED.
-   - "layoutHint": Choose the BEST layout from: 'title', 'section', 'split', 'columns', 'comparison', 'timeline'. REQUIRED.
-     • Use 'title' only for the first/cover slide.
-     • Use 'section' for transition/divider slides with little content.
-     • Use 'columns' when there are 3-4 independent parallel items (features, options, pillars).
-     • Use 'comparison' when exactly two things/lists are being compared side-by-side (e.g. Q3 vs Q4 features, Pros vs Cons).
-     • Use 'timeline' when content contains chronological milestones or dated events.
-     • Use 'split' (default) for most content slides with a clear title + supporting points.
-   - "bullets": Array of 3-6 concise summary strings (each ≤10 words). Capture the KEY takeaways only.
-     Use [] for 'section' or 'title' slides.
-   - "bodyText": Array with at most 1 kicker sentence (≤15 words) — the single most important idea.
-     Use [] for 'section', 'title', 'columns', 'comparison', or 'timeline' slides.
+   - "title": Keep as-is or trim to ≤8 words, applying the "slide slogan technique" (main takeaway). REQUIRED.
+   - "layoutHint": Choose the BEST layout from: 'title', 'section', 'split', 'columns', 'comparison', 'timeline', 'image', 'spotlight'. REQUIRED.
+      • Use 'title' only for the first/cover slide.
+      • Use 'section' for transition/divider slides.
+      • Use 'columns' when there are 3-4 independent parallel items (features, options, pillars).
+      • Use 'comparison' when exactly two things/lists are being compared side-by-side.
+      • Use 'timeline' when content contains chronological milestones or dated events.
+      • Use 'spotlight' when the slide focuses on a single massive metric, number, or key statement.
+      • Use 'split' (default) for most content slides with a clear title + supporting points.
+   - "bullets": Array of 2-5 concise summary strings (each ≤10 words). Capture the KEY takeaways only. Limit to 3 bullets if target style is minimalist. Use [] for 'section' or 'title' slides.
+   - "bodyText": Array with at most 1 kicker sentence (≤15 words) — the single most important idea. Use [] for 'section', 'title', 'columns', 'comparison', or 'timeline' slides.
    - "items": ONLY for 'columns' layout: array of {title, summaryBullets[]} objects.
      ONLY for 'timeline' layout: array of {year, title, summary} objects.
      Omit this field for all other layouts.
+   - "dominantVisualElement": A short description (≤8 words) of the primary visual element (e.g., "3-stage process flow diagram", "team photo", "metric: 85%").
+   - "primaryColorEmphasis": Suggest background color contrast mode for the slide ('light', 'dark', 'accent').
+   - "emotionalTone": Emotional tone of the slide ('authority', 'urgency', 'trust', 'excitement').
 5. Every slide in the input is distinct and MUST be processed. Do not skip, drop, or merge slides, even if they have duplicate or similar titles.
 6. For the "items" field in 'columns' layout: group parallel bullet points under their respective header or category (e.g. if the slide contains multiple plain text headers/labels followed by bullets, create a column/item for each header where its title is the header text, and its summaryBullets are the bullets under it). Do not list bullets as separate column titles; group them. Include all relevant columns/groups present in the source (up to 6 columns).
 7. For the "items" field in 'timeline' layout: extract all milestones/events from the content (up to 6 items).
 8. For 'comparison' layout: use when comparing exactly two categories/lists (e.g. Q3 vs Q4, Pros vs Cons).
-9. Do NOT omit any distinct header, section, or category present in the slide content. If a slide contains multiple groups or headers (e.g. "Why This Matters:" or distinct labels), ensure every group is represented in the output (either as columns in 'columns' layout, or as separate bullet lists in 'split'/'standard' layout).
+9. Do NOT omit any distinct header, section, or category present in the slide content. If a slide contains multiple groups or headers, ensure every group is represented in the output.
 
 Input:
 ${JSON.stringify(sectionsForAI, null, 2)}
@@ -772,7 +831,10 @@ Respond ONLY with a raw JSON array of exactly ${slideCount} objects. No markdown
                                       bodyText: aiSlide.bodyText || [],
                                       items: aiSlide.items || [],
                                       elements: aiElements,
-                                      startLine: originalSection.startLine
+                                      startLine: originalSection.startLine,
+                                      dominantVisualElement: aiSlide.dominantVisualElement || '',
+                                      primaryColorEmphasis: aiSlide.primaryColorEmphasis || 'light',
+                                      emotionalTone: aiSlide.emotionalTone || ''
                                     };
                                   });
 

--- a/src/lib/pptxExport.ts
+++ b/src/lib/pptxExport.ts
@@ -952,7 +952,8 @@ export function parseMarkdownToSlides(content: string): SlideData[] {
     } else if (currentSection) {
       currentSection.lines.push(line);
     } else if (trimmed.length > 0) {
-      currentSection = { title: "Introduction", lines: [line], isMajor: false, startLine: i };
+      const defaultTitle = sections.length === 0 ? "Introduction" : "End Slide";
+      currentSection = { title: defaultTitle, lines: [line], isMajor: false, startLine: i };
     }
   }
   if (currentSection) sections.push(currentSection);
@@ -1020,7 +1021,7 @@ export function parseMarkdownToSlides(content: string): SlideData[] {
         inTable = false;
       }
 
-      const subBulletMatch = line.match(/^(?:\s{2,}|\t)[-*]\s+(.*)/);
+      const subBulletMatch = line.match(/^(?:\s{2,}|\t)(?:[-*]|\d+\.)\s+(.*)/);
       if (subBulletMatch) {
         const parentIdx = slide.bullets.length - 1;
         const subText = subBulletMatch[1].trim();
@@ -1033,7 +1034,7 @@ export function parseMarkdownToSlides(content: string): SlideData[] {
         continue;
       }
 
-      const bulletMatch = line.match(/^[-*]\s+(.*)/);
+      const bulletMatch = line.match(/^(?:[-*]|\d+\.)\s+(.*)/);
       if (bulletMatch) {
         const bulletText = bulletMatch[1].trim();
         slide.bullets.push(bulletText);

--- a/src/lib/pptxExport.ts
+++ b/src/lib/pptxExport.ts
@@ -968,7 +968,11 @@ export function parseMarkdownToSlides(content: string): SlideData[] {
       startLine: section.startLine
     };
     
-    let inTable = false, tableHeaders: string[] = [], tableRows: string[][] = [], inSpeakerNotes = false, speakerNotesLines: string[] = [];
+    let inTable = false, tableHeaders: string[] = [], tableRows: string[][] = [];
+    let inSpeakerNotes = false, speakerNotesLines: string[] = [];
+    // orderedNotesLines captures content in document order (bodyText and bullets interleaved)
+    // so speaker notes reflect the original reading flow, not a re-grouped dump.
+    const orderedNotesLines: string[] = [];
 
     for (const line of section.lines) {
       const trimmed = line.trim();
@@ -1016,23 +1020,46 @@ export function parseMarkdownToSlides(content: string): SlideData[] {
         inTable = false;
       }
 
-      const bulletMatch = line.match(/^[-*]\s+(.*)/);
-      if (bulletMatch) { slide.bullets.push(bulletMatch[1].trim()); continue; }
-
       const subBulletMatch = line.match(/^(?:\s{2,}|\t)[-*]\s+(.*)/);
       if (subBulletMatch) {
         const parentIdx = slide.bullets.length - 1;
+        const subText = subBulletMatch[1].trim();
         if (parentIdx >= 0) {
           if (!slide.subBullets.has(parentIdx)) slide.subBullets.set(parentIdx, []);
-          slide.subBullets.get(parentIdx)!.push(subBulletMatch[1].trim());
+          slide.subBullets.get(parentIdx)!.push(subText);
+          // Add sub-bullet to ordered notes with indentation marker
+          orderedNotesLines.push(`  • ${stripBold(subText)}`);
         }
         continue;
       }
 
-      if (trimmed.length > 0) slide.bodyText.push(trimmed);
+      const bulletMatch = line.match(/^[-*]\s+(.*)/);
+      if (bulletMatch) {
+        const bulletText = bulletMatch[1].trim();
+        slide.bullets.push(bulletText);
+        // Add bullet to ordered notes so it appears in document order
+        orderedNotesLines.push(`• ${stripBold(bulletText)}`);
+        continue;
+      }
+
+      if (trimmed.length > 0) {
+        slide.bodyText.push(trimmed);
+        // Add body paragraph to ordered notes in document order
+        orderedNotesLines.push(stripBold(trimmed));
+      }
     }
     if (inTable && tableHeaders.length > 0) slide.table = { headers: tableHeaders, rows: tableRows };
-    if (speakerNotesLines.length > 0) slide.speakerNotes = speakerNotesLines.join('\n');
+
+    // Speaker notes priority: explicit "**Speaker Notes:**" block wins; otherwise use
+    // the ordered notes built from document line traversal (preserves interleave order).
+    if (speakerNotesLines.length > 0) {
+      slide.speakerNotes = speakerNotesLines.join('\n');
+    } else if (orderedNotesLines.length > 0) {
+      slide.speakerNotes = orderedNotesLines.join('\n');
+    }
+    // fullText always mirrors speakerNotes so downstream consumers get ordered content
+    slide.fullText = slide.speakerNotes || '';
+
     if (slide.bullets.length > 0 || slide.bodyText.length > 0 || slide.table || slide.header || (slide.images && slide.images.length > 0)) slides.push(slide);
   }
   return slides;

--- a/src/lib/pptxExport.ts
+++ b/src/lib/pptxExport.ts
@@ -15,6 +15,15 @@ export interface BrandSettings {
   };
 }
 
+export interface SlideElement {
+  type: 'paragraph' | 'bullet';
+  text: string;
+  isLabel?: boolean;
+  isGoal?: boolean;
+  indentLevel?: number;
+  subBullets?: string[];
+}
+
 export interface SlideData {
   title: string;
   header?: string;
@@ -29,6 +38,7 @@ export interface SlideData {
   startLine: number;
   items?: any[];
   fullText?: string;
+  elements?: SlideElement[];
 }
 
 export const SUPPORTED_LAYOUTS = [
@@ -106,17 +116,29 @@ export const defineModernMasters = (pres: any, primaryColor: string, bgColor: st
 export const buildTimelineSlide = (pres: any, slideData: any, primaryColor: string) => {
   const notesText = slideData.speakerNotes || slideData.fullText || "";
 
-  const milestones = (slideData.bullets || []).map((b: string, idx: number) => {
-    const match = b.match(/^((?:19|20)\d{2}|[A-Za-z]{3}\s\d+|[A-Za-z]+)\s*[:-]\s*(.*)/) || [null, b, ""];
-    const year = match[1] || b;
-    const title = match[2] || b;
-    const subs = slideData.subBullets?.get(idx) || [];
-    return {
-      year: stripBold(year),
-      title: stripBold(title),
-      summary: subs.map((s: string) => stripBold(s)).join("\n")
-    };
-  });
+  let milestones = [];
+  if (Array.isArray(slideData.items) && slideData.items.length > 0) {
+    milestones = slideData.items.map((item: any) => {
+      const summaryList = item.summaryBullets || item.bullets || (item.summary ? [item.summary] : []);
+      return {
+        year: stripBold(item.year || ""),
+        title: stripBold(item.title || ""),
+        summary: (Array.isArray(summaryList) ? summaryList : [summaryList]).map((s: any) => stripBold(String(s))).join("\n")
+      };
+    });
+  } else {
+    milestones = (slideData.bullets || []).map((b: string, idx: number) => {
+      const match = b.match(/^((?:19|20)\d{2}|[A-Za-z]{3}\s\d+|[A-Za-z]+)\s*[:-]\s*(.*)/) || [null, b, ""];
+      const year = match[1] || b;
+      const title = match[2] || b;
+      const subs = slideData.subBullets?.get(idx) || [];
+      return {
+        year: stripBold(year),
+        title: stripBold(title),
+        summary: subs.map((s: string) => stripBold(s)).join("\n")
+      };
+    });
+  }
 
   if (milestones.length === 0) return;
 
@@ -188,13 +210,24 @@ export const buildColumnSlide = (pres: any, slideData: any, primaryColor: string
     fontFace: headingFont || "Inter"
   });
 
-  const cols = (slideData.bullets || []).map((b: string, idx: number) => {
-    const subs = slideData.subBullets?.get(idx) || [];
-    return {
-      title: stripBold(b),
-      summaryBullets: subs.map((s: string) => stripBold(s))
-    };
-  });
+  let cols = [];
+  if (Array.isArray(slideData.items) && slideData.items.length > 0) {
+    cols = slideData.items.map((item: any) => {
+      const bulletList = item.summaryBullets || item.bullets || (item.summary ? [item.summary] : []);
+      return {
+        title: stripBold(item.title || ""),
+        summaryBullets: (Array.isArray(bulletList) ? bulletList : [bulletList]).map((s: any) => stripBold(String(s)))
+      };
+    });
+  } else {
+    cols = (slideData.bullets || []).map((b: string, idx: number) => {
+      const subs = slideData.subBullets?.get(idx) || [];
+      return {
+        title: stripBold(b),
+        summaryBullets: subs.map((s: string) => stripBold(s))
+      };
+    });
+  }
 
   if (cols.length === 0) return;
 
@@ -286,6 +319,28 @@ export function normalizeSlideData(slide: any): SlideData {
     }
   }
 
+  let elements = slide.elements || [];
+  if (elements.length === 0) {
+    const tempBody = slide.bodyText || [];
+    tempBody.forEach((t: string) => {
+      elements.push({
+        type: 'paragraph',
+        text: t,
+        isLabel: t.includes(':') && t.length < 60,
+        isGoal: t.toLowerCase().startsWith('goal:')
+      });
+    });
+    bullets.forEach((b: string, idx: number) => {
+      const subs = subBullets.get(idx) || [];
+      elements.push({
+        type: 'bullet',
+        text: b,
+        indentLevel: 0,
+        subBullets: subs
+      });
+    });
+  }
+
   return {
     title: slide.title || "Untitled Slide",
     header: slide.header,
@@ -299,7 +354,8 @@ export function normalizeSlideData(slide: any): SlideData {
     charts: slide.charts,
     layoutHint: slide.layoutHint,
     startLine: slide.startLine || 0,
-    items: slide.items
+    items: slide.items || [],
+    elements: elements
   };
 }
 
@@ -558,91 +614,148 @@ function addSplitSlides(pres: pptxgen, data: SlideData, headingFont: string, bod
     return false;
   };
 
-  // bodyText items are kicker/thesis sentences from the AI pipeline — display prominently
-  let hasBodyText = false;
-  for (const paragraph of data.bodyText) {
-    const text = stripBold(paragraph);
-    if (!text) continue;
-    hasBodyText = true;
-    const fontSize = 18; // Prominent kicker size
-    const height = estimateTextHeight(text, fontSize, RIGHT_WIDTH);
-    
-    checkOverflow(height + 0.2);
+  if (data.elements && data.elements.length > 0) {
+    for (const el of data.elements) {
+      if (el.type === 'paragraph') {
+        const text = stripBold(el.text);
+        if (!text) continue;
+        const fontSize = 18; // Prominent kicker size
+        const height = estimateTextHeight(text, fontSize, RIGHT_WIDTH);
+        
+        checkOverflow(height + 0.2);
 
-    currentSlide.addText(text, {
-      x: RIGHT_START_X, y: currentY, w: RIGHT_WIDTH, h: height,
-      fontSize: fontSize, fontFace: bodyFont, 
-      color: RIGHT_TEXT_COLOR, 
-      bold: true,
-      italic: false,
-      valign: "top"
-    });
-    currentY += height + 0.22;
-  }
+        currentSlide.addText(text, {
+          x: RIGHT_START_X, y: currentY, w: RIGHT_WIDTH, h: height,
+          fontSize: fontSize, fontFace: bodyFont, 
+          color: RIGHT_TEXT_COLOR, 
+          bold: true,
+          italic: false,
+          valign: "top"
+        });
+        currentY += height + 0.22;
+      } else if (el.type === 'bullet') {
+        const bText = stripBold(el.text);
+        const bHeight = estimateTextHeight(bText, 16, RIGHT_WIDTH - 0.2); 
 
-  // Thin white separator between kicker and bullets for visual hierarchy
-  if (hasBodyText && data.bullets.length > 0) {
-    currentSlide.addShape(pres.ShapeType.rect, {
-      x: RIGHT_START_X, y: currentY, w: 1.5, h: 0.02,
-      fill: { color: "FFFFFF", transparency: 40 },
-      line: { color: "FFFFFF", transparency: 40, width: 0 }
-    });
-    currentY += 0.22;
-  }
+        const subItems = el.subBullets || [];
+        let subHeightTotal = 0;
+        const subProps: pptxgen.TextProps[] = subItems.map(s => {
+          const sText = stripBold(s);
+          const sHeight = estimateTextHeight(sText, 13, RIGHT_WIDTH - 0.5);
+          subHeightTotal += sHeight + 0.06;
+          return {
+            text: sText,
+            options: { bullet: { type: "bullet" }, fontSize: 13, fontFace: bodyFont, color: RIGHT_SUB_COLOR, indentLevel: 1, paraSpaceAfter: 3 }
+          };
+        });
 
-  if (data.bullets.length > 0) {
-    let bulletGroup: pptxgen.TextProps[] = [];
-    let groupStartY = currentY;
+        const totalItemHeight = bHeight + subHeightTotal + 0.18;
+        checkOverflow(totalItemHeight);
 
-    for (let bIdx = 0; bIdx < data.bullets.length; bIdx++) {
-      const bText = stripBold(data.bullets[bIdx]);
-      const bHeight = estimateTextHeight(bText, 16, RIGHT_WIDTH - 0.2); 
-      
-      const subItems = data.subBullets.get(bIdx) || [];
-      let subHeightTotal = 0;
-      const subProps: pptxgen.TextProps[] = subItems.map(s => {
-        const sText = stripBold(s);
-        const sHeight = estimateTextHeight(sText, 13, RIGHT_WIDTH - 0.5);
-        subHeightTotal += sHeight + 0.06;
-        return {
-          text: sText,
-          options: { bullet: { type: "bullet" }, fontSize: 13, fontFace: bodyFont, color: RIGHT_SUB_COLOR, indentLevel: 1, paraSpaceAfter: 3 }
-        };
-      });
+        const bulletProps: pptxgen.TextProps[] = [
+          {
+            text: bText,
+            options: {
+              bullet: { type: "bullet" }, fontSize: 16, fontFace: bodyFont, color: RIGHT_TEXT_COLOR,
+              bold: hasBoldPrefix(el.text), paraSpaceAfter: 5, indentLevel: 0
+            }
+          },
+          ...subProps
+        ];
 
-      const totalItemHeight = bHeight + subHeightTotal + 0.18;
-
-      if (currentY + totalItemHeight > SLIDE_HEIGHT - FOOTER_RESERVE) {
-          if (bulletGroup.length > 0) {
-              currentSlide.addText(bulletGroup, { 
-                  x: RIGHT_START_X, y: groupStartY, w: RIGHT_WIDTH, 
-                  h: currentY - groupStartY, valign: "top" 
-              });
-          }
-          slideNum++;
-          currentSlide = createNewSplitSlide(pres, data, headingFont, primary, slideNum);
-          if (notesText) currentSlide.addNotes(notesText);
-          currentY = RIGHT_PADDING_TOP;
-          groupStartY = currentY;
-          bulletGroup = [];
+        currentSlide.addText(bulletProps, {
+          x: RIGHT_START_X, y: currentY, w: RIGHT_WIDTH, h: totalItemHeight,
+          valign: "top"
+        });
+        currentY += totalItemHeight;
       }
-
-      bulletGroup.push({
-        text: bText,
-        options: {
-          bullet: { type: "bullet" }, fontSize: 16, fontFace: bodyFont, color: RIGHT_TEXT_COLOR,
-          bold: hasBoldPrefix(data.bullets[bIdx]), paraSpaceAfter: 5, indentLevel: 0
-        }
-      });
-      bulletGroup.push(...subProps);
-      currentY += totalItemHeight;
     }
+  } else {
+    // Fallback: legacy code in case elements is missing
+    let hasBodyText = false;
+    for (const paragraph of data.bodyText) {
+      const text = stripBold(paragraph);
+      if (!text) continue;
+      hasBodyText = true;
+      const fontSize = 18; // Prominent kicker size
+      const height = estimateTextHeight(text, fontSize, RIGHT_WIDTH);
+      
+      checkOverflow(height + 0.2);
 
-    if (bulletGroup.length > 0) {
-      currentSlide.addText(bulletGroup, {
-        x: RIGHT_START_X, y: groupStartY, w: RIGHT_WIDTH, h: currentY - groupStartY,
+      currentSlide.addText(text, {
+        x: RIGHT_START_X, y: currentY, w: RIGHT_WIDTH, h: height,
+        fontSize: fontSize, fontFace: bodyFont, 
+        color: RIGHT_TEXT_COLOR, 
+        bold: true,
+        italic: false,
         valign: "top"
       });
+      currentY += height + 0.22;
+    }
+
+    if (hasBodyText && data.bullets.length > 0) {
+      currentSlide.addShape(pres.ShapeType.rect, {
+        x: RIGHT_START_X, y: currentY, w: 1.5, h: 0.02,
+        fill: { color: "FFFFFF", transparency: 40 },
+        line: { color: "FFFFFF", transparency: 40, width: 0 }
+      });
+      currentY += 0.22;
+    }
+
+    if (data.bullets.length > 0) {
+      let bulletGroup: pptxgen.TextProps[] = [];
+      let groupStartY = currentY;
+
+      for (let bIdx = 0; bIdx < data.bullets.length; bIdx++) {
+        const bText = stripBold(data.bullets[bIdx]);
+        const bHeight = estimateTextHeight(bText, 16, RIGHT_WIDTH - 0.2); 
+        
+        const subItems = data.subBullets.get(bIdx) || [];
+        let subHeightTotal = 0;
+        const subProps: pptxgen.TextProps[] = subItems.map(s => {
+          const sText = stripBold(s);
+          const sHeight = estimateTextHeight(sText, 13, RIGHT_WIDTH - 0.5);
+          subHeightTotal += sHeight + 0.06;
+          return {
+            text: sText,
+            options: { bullet: { type: "bullet" }, fontSize: 13, fontFace: bodyFont, color: RIGHT_SUB_COLOR, indentLevel: 1, paraSpaceAfter: 3 }
+          };
+        });
+
+        const totalItemHeight = bHeight + subHeightTotal + 0.18;
+
+        if (currentY + totalItemHeight > SLIDE_HEIGHT - FOOTER_RESERVE) {
+            if (bulletGroup.length > 0) {
+                currentSlide.addText(bulletGroup, { 
+                    x: RIGHT_START_X, y: groupStartY, w: RIGHT_WIDTH, 
+                    h: currentY - groupStartY, valign: "top" 
+                });
+            }
+            slideNum++;
+            currentSlide = createNewSplitSlide(pres, data, headingFont, primary, slideNum);
+            if (notesText) currentSlide.addNotes(notesText);
+            currentY = RIGHT_PADDING_TOP;
+            groupStartY = currentY;
+            bulletGroup = [];
+        }
+
+        bulletGroup.push({
+          text: bText,
+          options: {
+            bullet: { type: "bullet" }, fontSize: 16, fontFace: bodyFont, color: RIGHT_TEXT_COLOR,
+            bold: hasBoldPrefix(data.bullets[bIdx]), paraSpaceAfter: 5, indentLevel: 0
+          }
+        });
+        bulletGroup.push(...subProps);
+        currentY += totalItemHeight;
+      }
+
+      if (bulletGroup.length > 0) {
+        currentSlide.addText(bulletGroup, {
+          x: RIGHT_START_X, y: groupStartY, w: RIGHT_WIDTH, h: currentY - groupStartY,
+          valign: "top"
+        });
+      }
     }
   }
 }
@@ -696,81 +809,143 @@ function addContentSlides(pres: pptxgen, data: SlideData, headingFont: string, b
     return false;
   };
 
-  for (const paragraph of data.bodyText) {
-    const text = stripBold(paragraph);
-    const isLabel = paragraph.includes(':') && paragraph.length < 60;
-    const isGoal = paragraph.toLowerCase().startsWith('goal:');
-    const fontSize = 18; 
-    const height = estimateTextHeight(text, fontSize, SLIDE_WIDTH - 1);
-    
-    checkOverflow(height + 0.1);
+  if (data.elements && data.elements.length > 0) {
+    for (const el of data.elements) {
+      if (el.type === 'paragraph') {
+        const text = stripBold(el.text);
+        const isLabel = el.isLabel || (el.text.includes(':') && el.text.length < 60);
+        const isGoal = el.isGoal || el.text.toLowerCase().startsWith('goal:');
+        const fontSize = 18;
+        const height = estimateTextHeight(text, fontSize, SLIDE_WIDTH - 1);
+        
+        checkOverflow(height + 0.1);
 
-    currentSlide.addText(text, {
-      x: MARGIN_X, y: currentY, w: SLIDE_WIDTH - 1, h: height,
-      fontSize: fontSize, fontFace: bodyFont, 
-      color: isLabel || isGoal ? primary : "2C2C2C",
-      valign: "top", 
-      italic: !isLabel && !isGoal,
-      bold: isLabel || isGoal
-    });
-    currentY += height + 0.2; 
-  }
+        currentSlide.addText(text, {
+          x: MARGIN_X, y: currentY, w: SLIDE_WIDTH - 1, h: height,
+          fontSize: fontSize, fontFace: bodyFont,
+          color: isLabel || isGoal ? primary : "2C2C2C",
+          valign: "top",
+          italic: !isLabel && !isGoal,
+          bold: isLabel || isGoal
+        });
+        currentY += height + 0.2;
+      } else if (el.type === 'bullet') {
+        const bText = stripBold(el.text);
+        const bFontSize = 20; // 20 is standard premium size (24 is too big)
+        const bHeight = estimateTextHeight(bText, bFontSize, SLIDE_WIDTH - 1.2);
 
-  if (data.bullets.length > 0) {
-    let bulletGroup: pptxgen.TextProps[] = [];
-    let groupStartY = currentY;
+        const subItems = el.subBullets || [];
+        let subHeightTotal = 0;
+        const subProps: pptxgen.TextProps[] = subItems.map(s => {
+          const sText = stripBold(s);
+          const sFontSize = 16;
+          const sHeight = estimateTextHeight(sText, sFontSize, SLIDE_WIDTH - 1.5);
+          subHeightTotal += sHeight + 0.05;
+          return {
+            text: sText,
+            options: { bullet: { type: "bullet" }, fontSize: sFontSize, fontFace: bodyFont, color: "666666", indentLevel: 1, paraSpaceAfter: 2 }
+          };
+        });
 
-    for (let bIdx = 0; bIdx < data.bullets.length; bIdx++) {
-      const bText = stripBold(data.bullets[bIdx]);
-      const bFontSize = 24; 
-      const bHeight = estimateTextHeight(bText, bFontSize, SLIDE_WIDTH - 1.2); 
-      
-      const subItems = data.subBullets.get(bIdx) || [];
-      let subHeightTotal = 0;
-      const subProps: pptxgen.TextProps[] = subItems.map(s => {
-        const sText = stripBold(s);
-        const sFontSize = 18; 
-        const sHeight = estimateTextHeight(sText, sFontSize, SLIDE_WIDTH - 1.5);
-        subHeightTotal += sHeight + 0.05;
-        return {
-          text: sText,
-          options: { bullet: { type: "bullet" }, fontSize: sFontSize, fontFace: bodyFont, color: "666666", indentLevel: 1, paraSpaceAfter: 2 }
-        };
-      });
+        const totalItemHeight = bHeight + subHeightTotal + 0.2;
+        checkOverflow(totalItemHeight);
 
-      const totalItemHeight = bHeight + subHeightTotal + 0.2;
+        const bulletProps: pptxgen.TextProps[] = [
+          {
+            text: bText,
+            options: {
+              bullet: { type: "bullet" }, fontSize: bFontSize, fontFace: bodyFont, color: "222222",
+              bold: hasBoldPrefix(el.text), paraSpaceAfter: 4, indentLevel: 0
+            }
+          },
+          ...subProps
+        ];
 
-      if (currentY + totalItemHeight > SLIDE_HEIGHT - FOOTER_RESERVE) {
-          if (bulletGroup.length > 0) {
-              currentSlide.addText(bulletGroup, { 
-                  x: MARGIN_X, y: groupStartY, w: SLIDE_WIDTH - 1, 
-                  h: currentY - groupStartY, valign: "top" 
-              });
-          }
-          slideNum++;
-          currentSlide = createNewContentSlide(pres, data, headingFont, primary, slideNum);
-          if (notesText) currentSlide.addNotes(notesText);
-          currentY = CONTENT_START_Y;
-          groupStartY = currentY;
-          bulletGroup = [];
+        currentSlide.addText(bulletProps, {
+          x: MARGIN_X, y: currentY, w: SLIDE_WIDTH - 1, h: totalItemHeight,
+          valign: "top"
+        });
+        currentY += totalItemHeight;
       }
+    }
+  } else {
+    // Fallback: legacy code in case elements is missing
+    for (const paragraph of data.bodyText) {
+      const text = stripBold(paragraph);
+      const isLabel = paragraph.includes(':') && paragraph.length < 60;
+      const isGoal = paragraph.toLowerCase().startsWith('goal:');
+      const fontSize = 18; 
+      const height = estimateTextHeight(text, fontSize, SLIDE_WIDTH - 1);
+      
+      checkOverflow(height + 0.1);
 
-      bulletGroup.push({
-        text: bText,
-        options: {
-          bullet: { type: "bullet" }, fontSize: bFontSize, fontFace: bodyFont, color: "222222",
-          bold: hasBoldPrefix(data.bullets[bIdx]), paraSpaceAfter: 4, indentLevel: 0
-        }
+      currentSlide.addText(text, {
+        x: MARGIN_X, y: currentY, w: SLIDE_WIDTH - 1, h: height,
+        fontSize: fontSize, fontFace: bodyFont, 
+        color: isLabel || isGoal ? primary : "2C2C2C",
+        valign: "top", 
+        italic: !isLabel && !isGoal,
+        bold: isLabel || isGoal
       });
-      bulletGroup.push(...subProps);
-      currentY += totalItemHeight;
+      currentY += height + 0.2; 
     }
 
-    if (bulletGroup.length > 0) {
-      currentSlide.addText(bulletGroup, {
-        x: MARGIN_X, y: groupStartY, w: SLIDE_WIDTH - 1, h: currentY - groupStartY,
-        valign: "top"
-      });
+    if (data.bullets.length > 0) {
+      let bulletGroup: pptxgen.TextProps[] = [];
+      let groupStartY = currentY;
+
+      for (let bIdx = 0; bIdx < data.bullets.length; bIdx++) {
+        const bText = stripBold(data.bullets[bIdx]);
+        const bFontSize = 24; 
+        const bHeight = estimateTextHeight(bText, bFontSize, SLIDE_WIDTH - 1.2); 
+        
+        const subItems = data.subBullets.get(bIdx) || [];
+        let subHeightTotal = 0;
+        const subProps: pptxgen.TextProps[] = subItems.map(s => {
+          const sText = stripBold(s);
+          const sFontSize = 18; 
+          const sHeight = estimateTextHeight(sText, sFontSize, SLIDE_WIDTH - 1.5);
+          subHeightTotal += sHeight + 0.05;
+          return {
+            text: sText,
+            options: { bullet: { type: "bullet" }, fontSize: sFontSize, fontFace: bodyFont, color: "666666", indentLevel: 1, paraSpaceAfter: 2 }
+          };
+        });
+
+        const totalItemHeight = bHeight + subHeightTotal + 0.2;
+
+        if (currentY + totalItemHeight > SLIDE_HEIGHT - FOOTER_RESERVE) {
+            if (bulletGroup.length > 0) {
+                currentSlide.addText(bulletGroup, { 
+                    x: MARGIN_X, y: groupStartY, w: SLIDE_WIDTH - 1, 
+                    h: currentY - groupStartY, valign: "top" 
+                });
+            }
+            slideNum++;
+            currentSlide = createNewContentSlide(pres, data, headingFont, primary, slideNum);
+            if (notesText) currentSlide.addNotes(notesText);
+            currentY = CONTENT_START_Y;
+            groupStartY = currentY;
+            bulletGroup = [];
+        }
+
+        bulletGroup.push({
+          text: bText,
+          options: {
+            bullet: { type: "bullet" }, fontSize: bFontSize, fontFace: bodyFont, color: "222222",
+            bold: hasBoldPrefix(data.bullets[bIdx]), paraSpaceAfter: 4, indentLevel: 0
+          }
+        });
+        bulletGroup.push(...subProps);
+        currentY += totalItemHeight;
+      }
+
+      if (bulletGroup.length > 0) {
+        currentSlide.addText(bulletGroup, {
+          x: MARGIN_X, y: groupStartY, w: SLIDE_WIDTH - 1, h: currentY - groupStartY,
+          valign: "top"
+        });
+      }
     }
   }
 
@@ -966,7 +1141,9 @@ export function parseMarkdownToSlides(content: string): SlideData[] {
       bodyText: [],
       images: [],
       layoutHint: section.isMajor ? 'section' : undefined,
-      startLine: section.startLine
+      startLine: section.startLine,
+      elements: [],
+      items: []
     };
     
     let inTable = false, tableHeaders: string[] = [], tableRows: string[][] = [];
@@ -974,6 +1151,9 @@ export function parseMarkdownToSlides(content: string): SlideData[] {
     // orderedNotesLines captures content in document order (bodyText and bullets interleaved)
     // so speaker notes reflect the original reading flow, not a re-grouped dump.
     const orderedNotesLines: string[] = [];
+
+    let currentItem: any = null;
+    const items: any[] = [];
 
     for (const line of section.lines) {
       const trimmed = line.trim();
@@ -1031,6 +1211,24 @@ export function parseMarkdownToSlides(content: string): SlideData[] {
           // Add sub-bullet to ordered notes with indentation marker
           orderedNotesLines.push(`  • ${stripBold(subText)}`);
         }
+
+        const lastEl = slide.elements![slide.elements!.length - 1];
+        if (lastEl && lastEl.type === 'bullet') {
+          if (!lastEl.subBullets) lastEl.subBullets = [];
+          lastEl.subBullets.push(subText);
+        }
+
+        if (currentItem) {
+          if (currentItem.year !== undefined) {
+            if (currentItem.summary) {
+              currentItem.summary += "\n" + subText;
+            } else {
+              currentItem.summary = subText;
+            }
+          }
+          if (!currentItem.summaryBullets) currentItem.summaryBullets = [];
+          currentItem.summaryBullets.push(subText);
+        }
         continue;
       }
 
@@ -1040,6 +1238,30 @@ export function parseMarkdownToSlides(content: string): SlideData[] {
         slide.bullets.push(bulletText);
         // Add bullet to ordered notes so it appears in document order
         orderedNotesLines.push(`• ${stripBold(bulletText)}`);
+
+        slide.elements!.push({
+          type: 'bullet',
+          text: bulletText,
+          indentLevel: 0,
+          subBullets: []
+        });
+
+        const timelineMatch = bulletText.match(/^((?:19|20)\d{2}|[A-Za-z]{3}\s\d+|[A-Za-z]+)\s*[:-]\s*(.*)/);
+        if (timelineMatch) {
+          currentItem = { 
+            year: timelineMatch[1].trim(), 
+            title: timelineMatch[2].trim(), 
+            summary: "",
+            summaryBullets: []
+          };
+          items.push(currentItem);
+        } else {
+          if (!currentItem || currentItem.year !== undefined) {
+            currentItem = { title: "", summaryBullets: [] };
+            items.push(currentItem);
+          }
+          currentItem.summaryBullets.push(bulletText);
+        }
         continue;
       }
 
@@ -1047,9 +1269,26 @@ export function parseMarkdownToSlides(content: string): SlideData[] {
         slide.bodyText.push(trimmed);
         // Add body paragraph to ordered notes in document order
         orderedNotesLines.push(stripBold(trimmed));
+
+        slide.elements!.push({
+          type: 'paragraph',
+          text: trimmed,
+          isLabel: trimmed.includes(':') && trimmed.length < 60,
+          isGoal: trimmed.toLowerCase().startsWith('goal:')
+        });
+
+        currentItem = { title: trimmed, summaryBullets: [] };
+        items.push(currentItem);
       }
     }
     if (inTable && tableHeaders.length > 0) slide.table = { headers: tableHeaders, rows: tableRows };
+
+    if (items.length > 0) {
+      slide.items = items.filter(item => {
+        if (item.year !== undefined) return true;
+        return item.title || (item.summaryBullets && item.summaryBullets.length > 0);
+      });
+    }
 
     // Speaker notes priority: explicit "**Speaker Notes:**" block wins; otherwise use
     // the ordered notes built from document line traversal (preserves interleave order).

--- a/src/lib/pptxExport.ts
+++ b/src/lib/pptxExport.ts
@@ -34,11 +34,14 @@ export interface SlideData {
   table?: { headers: string[]; rows: string[][] };
   images?: { path: string; alt?: string }[];
   charts?: { type: string; data: any }[];
-  layoutHint?: 'standard' | 'split' | 'section' | 'title' | 'comparison' | 'columns' | 'timeline' | 'image';
+  layoutHint?: 'standard' | 'split' | 'section' | 'title' | 'comparison' | 'columns' | 'timeline' | 'image' | 'spotlight';
   startLine: number;
   items?: any[];
   fullText?: string;
   elements?: SlideElement[];
+  dominantVisualElement?: string;
+  primaryColorEmphasis?: 'light' | 'dark' | 'accent';
+  emotionalTone?: string;
 }
 
 export const SUPPORTED_LAYOUTS = [
@@ -50,6 +53,7 @@ export const SUPPORTED_LAYOUTS = [
   { id: 'columns', label: 'Multi-Column', description: '3-4 columns for key features' },
   { id: 'timeline', label: 'Timeline', description: 'Horizontal layout for milestones' },
   { id: 'image', label: 'Image Focus', description: 'Large image with caption' },
+  { id: 'spotlight', label: 'Spotlight', description: 'Large metric, statistic, or key fact callout' },
 ] as const;
 
 // Layout constants for a standard 10x5.625 inch slide (16:9)
@@ -409,6 +413,36 @@ export async function exportToPptx(markdownOrSlides: string | SlideData[], brand
     ]
   });
 
+  // Dynamic Dark/Accent Masters based on brand colors
+  const isLightColor = (hex: string) => {
+    const rgb = parseInt(hex, 16);
+    if (isNaN(rgb)) return false;
+    const r = (rgb >> 16) & 0xff;
+    const g = (rgb >> 8) & 0xff;
+    const b = rgb & 0xff;
+    const luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    return luma > 200; // threshold for "light" colors
+  };
+
+  const darkBgColor = isLightColor(primary) ? "1E293B" : primary;
+  const accentBgColor = isLightColor(accent) ? "EE6C4D" : accent;
+
+  pres.defineSlideMaster({
+    title: "DARK_MASTER",
+    background: { color: darkBgColor },
+    objects: [
+      { rect: { x: 0, y: 0, w: "100%", h: 0.1, fill: { color: accent } } }
+    ]
+  });
+
+  pres.defineSlideMaster({
+    title: "ACCENT_MASTER",
+    background: { color: accentBgColor },
+    objects: [
+      { rect: { x: 0, y: 0, w: "100%", h: 0.1, fill: { color: darkBgColor } } }
+    ]
+  });
+
   defineModernMasters(pres, primary, bgColor);
 
   let parsedSlides: SlideData[] = [];
@@ -468,6 +502,8 @@ export async function exportToPptx(markdownOrSlides: string | SlideData[], brand
             buildTimelineSlide(pres, slideData, primary);
         } else if (layout === 'image') {
             addImageSlide(pres, slideData, headingFont, bodyFont, primary);
+        } else if (layout === 'spotlight') {
+            addSpotlightSlide(pres, slideData, headingFont, bodyFont, primary, accent, textColor);
         } else {
             addContentSlides(pres, slideData, headingFont, bodyFont, primary, textColor);
         }
@@ -483,13 +519,20 @@ export async function exportToPptx(markdownOrSlides: string | SlideData[], brand
   }
 }
 
-export function chooseLayout(data: SlideData): 'standard' | 'split' | 'section' | 'comparison' | 'columns' | 'timeline' | 'image' | 'title' {
+export function chooseLayout(data: SlideData): 'standard' | 'split' | 'section' | 'comparison' | 'columns' | 'timeline' | 'image' | 'title' | 'spotlight' {
   if (data.layoutHint) return data.layoutHint as any;
 
   const titleLower = data.title.toLowerCase();
   const isGeneric = titleLower.includes('question') || titleLower.includes('discussion') || titleLower.includes('vision');
   
   if (data.table) return 'standard';
+
+  // Detect numeric spotlight (single big number or metric)
+  const firstText = (data.bodyText[0] || data.bullets[0] || "").trim();
+  const metricRegex = /^([$€£¥]?[0-9.,]+[kMBmbtT%xX+]?|[0-9]+\+)/;
+  if (!isGeneric && data.bullets.length <= 2 && metricRegex.test(firstText)) {
+    return 'spotlight';
+  }
   
   const isComparison = !isGeneric && (titleLower.includes('vs') || 
                       titleLower.includes('comparison') ||
@@ -534,6 +577,64 @@ function addTitleSlide(pres: pptxgen, data: SlideData, headingFont: string, body
   }
 
   if (data.speakerNotes || data.fullText) slide.addNotes(data.speakerNotes || data.fullText || "");
+}
+
+function addSpotlightSlide(
+  pres: pptxgen,
+  data: SlideData,
+  headingFont: string,
+  bodyFont: string,
+  primary: string,
+  _accent: string,
+  _textColor: string
+) {
+  const isDark = data.primaryColorEmphasis === 'dark';
+  const isAccent = data.primaryColorEmphasis === 'accent';
+  const masterName = isDark ? "DARK_MASTER" : (isAccent ? "ACCENT_MASTER" : "MASTER_SLIDE");
+  const slide = pres.addSlide({ masterName });
+  
+  if (data.speakerNotes || data.fullText) {
+    slide.addNotes(data.speakerNotes || data.fullText || "");
+  }
+
+  const titleCol = (isDark || isAccent) ? "FFFFFF" : primary;
+  const numCol = (isDark || isAccent) ? "FFFFFF" : primary;
+  const capCol = (isDark || isAccent) ? "E2E8F0" : "4A5568";
+
+  // Slogan/Takeaway Title
+  slide.addText(data.title, {
+    x: MARGIN_X, y: HEADER_Y, w: SLIDE_WIDTH - (MARGIN_X * 2), h: HEADER_HEIGHT,
+    fontSize: 28, fontFace: headingFont, color: titleCol, bold: true
+  });
+
+  // Extract metric
+  let bigNumber = "";
+  let caption = "";
+  const sourceText = data.bodyText[0] || data.bullets[0] || "";
+  const metricRegex = /^([$€£¥]?[0-9.,]+[kMBmbtT%xX+]?|[0-9]+\+)/;
+  const match = sourceText.match(metricRegex);
+
+  if (match) {
+    bigNumber = match[1];
+    caption = sourceText.replace(bigNumber, "").trim().replace(/^[:-]\s*/, "");
+  } else {
+    bigNumber = data.bullets[0] || "100%";
+    caption = data.bullets.slice(1).join("\n") || data.bodyText.join("\n") || "";
+  }
+
+  // Draw giant number
+  slide.addText(bigNumber, {
+    x: MARGIN_X, y: 1.8, w: SLIDE_WIDTH - (MARGIN_X * 2), h: 1.8,
+    fontSize: 84, fontFace: headingFont, color: numCol, bold: true, align: "center", valign: "middle"
+  });
+
+  // Draw caption under number
+  if (caption) {
+    slide.addText(stripBold(caption), {
+      x: MARGIN_X + 0.5, y: 3.6, w: SLIDE_WIDTH - ((MARGIN_X + 0.5) * 2), h: 1.2,
+      fontSize: 20, fontFace: bodyFont, color: capCol, align: "center", valign: "top"
+    });
+  }
 }
 
 
@@ -794,20 +895,32 @@ function addImageSlide(pres: pptxgen, data: SlideData, headingFont: string, body
 function addContentSlides(pres: pptxgen, data: SlideData, headingFont: string, bodyFont: string, primary: string, textColor: string) {
   let currentY = CONTENT_START_Y;
   let slideNum = 1;
-  let currentSlide = createNewContentSlide(pres, data, headingFont, primary, slideNum);
+
+  // Decide theme background
+  const isDark = data.primaryColorEmphasis === 'dark';
+  const isAccent = data.primaryColorEmphasis === 'accent';
+  const defaultMaster = isDark ? "DARK_MASTER" : (isAccent ? "ACCENT_MASTER" : "MASTER_SLIDE");
+
+  let currentSlide = createNewContentSlide(pres, data, headingFont, primary, slideNum, defaultMaster);
   const notesText = data.speakerNotes || data.fullText || "";
   if (notesText) currentSlide.addNotes(notesText);
 
   const checkOverflow = (heightNeeded: number) => {
     if (currentY + heightNeeded > SLIDE_HEIGHT - FOOTER_RESERVE) {
       slideNum++;
-      currentSlide = createNewContentSlide(pres, data, headingFont, primary, slideNum);
+      currentSlide = createNewContentSlide(pres, data, headingFont, primary, slideNum, defaultMaster);
       if (notesText) currentSlide.addNotes(notesText);
       currentY = CONTENT_START_Y;
       return true;
     }
     return false;
   };
+
+  // Theme text colors
+  const normalTextColor = (isDark || isAccent) ? "FFFFFF" : textColor;
+  const labelTextColor = (isDark || isAccent) ? "FFFFFF" : primary;
+  const bulletTextColor = (isDark || isAccent) ? "FFFFFF" : "222222";
+  const subBulletTextColor = (isDark || isAccent) ? "D4E0F5" : "666666";
 
   if (data.elements && data.elements.length > 0) {
     for (const el of data.elements) {
@@ -823,7 +936,7 @@ function addContentSlides(pres: pptxgen, data: SlideData, headingFont: string, b
         currentSlide.addText(text, {
           x: MARGIN_X, y: currentY, w: SLIDE_WIDTH - 1, h: height,
           fontSize: fontSize, fontFace: bodyFont,
-          color: isLabel || isGoal ? primary : "2C2C2C",
+          color: isLabel || isGoal ? labelTextColor : normalTextColor,
           valign: "top",
           italic: !isLabel && !isGoal,
           bold: isLabel || isGoal
@@ -843,7 +956,7 @@ function addContentSlides(pres: pptxgen, data: SlideData, headingFont: string, b
           subHeightTotal += sHeight + 0.05;
           return {
             text: sText,
-            options: { bullet: { type: "bullet" }, fontSize: sFontSize, fontFace: bodyFont, color: "666666", indentLevel: 1, paraSpaceAfter: 2 }
+            options: { bullet: { type: "bullet" }, fontSize: sFontSize, fontFace: bodyFont, color: subBulletTextColor, indentLevel: 1, paraSpaceAfter: 2 }
           };
         });
 
@@ -854,7 +967,7 @@ function addContentSlides(pres: pptxgen, data: SlideData, headingFont: string, b
           {
             text: bText,
             options: {
-              bullet: { type: "bullet" }, fontSize: bFontSize, fontFace: bodyFont, color: "222222",
+              bullet: { type: "bullet" }, fontSize: bFontSize, fontFace: bodyFont, color: bulletTextColor,
               bold: hasBoldPrefix(el.text), paraSpaceAfter: 4, indentLevel: 0
             }
           },
@@ -882,7 +995,7 @@ function addContentSlides(pres: pptxgen, data: SlideData, headingFont: string, b
       currentSlide.addText(text, {
         x: MARGIN_X, y: currentY, w: SLIDE_WIDTH - 1, h: height,
         fontSize: fontSize, fontFace: bodyFont, 
-        color: isLabel || isGoal ? primary : "2C2C2C",
+        color: isLabel || isGoal ? labelTextColor : normalTextColor,
         valign: "top", 
         italic: !isLabel && !isGoal,
         bold: isLabel || isGoal
@@ -908,7 +1021,7 @@ function addContentSlides(pres: pptxgen, data: SlideData, headingFont: string, b
           subHeightTotal += sHeight + 0.05;
           return {
             text: sText,
-            options: { bullet: { type: "bullet" }, fontSize: sFontSize, fontFace: bodyFont, color: "666666", indentLevel: 1, paraSpaceAfter: 2 }
+            options: { bullet: { type: "bullet" }, fontSize: sFontSize, fontFace: bodyFont, color: subBulletTextColor, indentLevel: 1, paraSpaceAfter: 2 }
           };
         });
 
@@ -922,7 +1035,7 @@ function addContentSlides(pres: pptxgen, data: SlideData, headingFont: string, b
                 });
             }
             slideNum++;
-            currentSlide = createNewContentSlide(pres, data, headingFont, primary, slideNum);
+            currentSlide = createNewContentSlide(pres, data, headingFont, primary, slideNum, defaultMaster);
             if (notesText) currentSlide.addNotes(notesText);
             currentY = CONTENT_START_Y;
             groupStartY = currentY;
@@ -932,7 +1045,7 @@ function addContentSlides(pres: pptxgen, data: SlideData, headingFont: string, b
         bulletGroup.push({
           text: bText,
           options: {
-            bullet: { type: "bullet" }, fontSize: bFontSize, fontFace: bodyFont, color: "222222",
+            bullet: { type: "bullet" }, fontSize: bFontSize, fontFace: bodyFont, color: bulletTextColor,
             bold: hasBoldPrefix(data.bullets[bIdx]), paraSpaceAfter: 4, indentLevel: 0
           }
         });
@@ -1026,13 +1139,14 @@ function addContentSlides(pres: pptxgen, data: SlideData, headingFont: string, b
   }
 }
 
-function createNewContentSlide(pres: pptxgen, data: SlideData, headingFont: string, primary: string, slideNum: number) {
-  const slide = pres.addSlide({ masterName: "MASTER_SLIDE" });
+function createNewContentSlide(pres: pptxgen, data: SlideData, headingFont: string, primary: string, slideNum: number, masterName: string = "MASTER_SLIDE") {
+  const slide = pres.addSlide({ masterName });
   const displayTitle = (data.header || data.title || "Slide") + (slideNum > 1 ? ` (Cont. ${slideNum})` : "");
+  const titleColor = (masterName === "DARK_MASTER" || masterName === "ACCENT_MASTER") ? "FFFFFF" : primary;
   
   slide.addText(displayTitle, {
     x: MARGIN_X, y: HEADER_Y, w: "90%", h: HEADER_HEIGHT,
-    fontSize: 28, fontFace: headingFont, color: primary, bold: true
+    fontSize: 28, fontFace: headingFont, color: titleColor, bold: true
   });
   return slide;
 }

--- a/src/lib/pptxExport.ts
+++ b/src/lib/pptxExport.ts
@@ -618,14 +618,17 @@ function addSpotlightSlide(
     bigNumber = match[1];
     caption = sourceText.replace(bigNumber, "").trim().replace(/^[:-]\s*/, "");
   } else {
-    bigNumber = data.bullets[0] || "100%";
-    caption = data.bullets.slice(1).join("\n") || data.bodyText.join("\n") || "";
+    bigNumber = stripBold(sourceText || data.title || "");
+    const remainingBody = sourceText === data.bodyText[0] ? data.bodyText.slice(1) : data.bodyText;
+    const remainingBullets = sourceText === data.bullets[0] ? data.bullets.slice(1) : data.bullets;
+    caption = [...remainingBody, ...remainingBullets].map(stripBold).join("\n");
   }
 
-  // Draw giant number
+  // Draw giant number (scale size dynamically based on text length to avoid overflow)
+  const numFontSize = bigNumber.length > 20 ? 32 : (bigNumber.length > 10 ? 48 : 84);
   slide.addText(bigNumber, {
     x: MARGIN_X, y: 1.8, w: SLIDE_WIDTH - (MARGIN_X * 2), h: 1.8,
-    fontSize: 84, fontFace: headingFont, color: numCol, bold: true, align: "center", valign: "middle"
+    fontSize: numFontSize, fontFace: headingFont, color: numCol, bold: true, align: "center", valign: "middle"
   });
 
   // Draw caption under number
@@ -1077,7 +1080,7 @@ function addContentSlides(pres: pptxgen, data: SlideData, headingFont: string, b
         
         if (availableSpace < headerHeight + 0.5) {
             slideNum++;
-            currentSlide = createNewContentSlide(pres, data, headingFont, primary, slideNum);
+            currentSlide = createNewContentSlide(pres, data, headingFont, primary, slideNum, defaultMaster);
             if (notesText) currentSlide.addNotes(notesText);
             currentY = CONTENT_START_Y;
             availableSpace = SLIDE_HEIGHT - FOOTER_RESERVE - currentY;
@@ -1131,7 +1134,7 @@ function addContentSlides(pres: pptxgen, data: SlideData, headingFont: string, b
         
         if (tableRows.length > 0) {
             slideNum++;
-            currentSlide = createNewContentSlide(pres, data, headingFont, primary, slideNum);
+            currentSlide = createNewContentSlide(pres, data, headingFont, primary, slideNum, defaultMaster);
             if (notesText) currentSlide.addNotes(notesText);
             currentY = CONTENT_START_Y;
         }
@@ -1288,6 +1291,7 @@ export function parseMarkdownToSlides(content: string): SlideData[] {
         else if (val === 'timeline') slide.layoutHint = 'timeline';
         else if (val === 'title') slide.layoutHint = 'title';
         else if (val === 'image') slide.layoutHint = 'image';
+        else if (val === 'spotlight') slide.layoutHint = 'spotlight';
         else slide.header = stripBold(headerMatch[1]); 
         continue; 
       }

--- a/tests/presentation-layout.test.mjs
+++ b/tests/presentation-layout.test.mjs
@@ -52,12 +52,17 @@ function parseMarkdownToSlides(content) {
       bodyText: [],
       images: [],
       layoutHint: section.isMajor ? 'section' : undefined,
-      startLine: section.startLine
+      startLine: section.startLine,
+      elements: [],
+      items: []
     };
 
     let inTable = false, tableHeaders = [], tableRows = [];
     let inSpeakerNotes = false, speakerNotesLines = [];
     const orderedNotesLines = [];
+
+    let currentItem = null;
+    const items = [];
 
     for (const line of section.lines) {
       const trimmed = line.trim();
@@ -108,6 +113,24 @@ function parseMarkdownToSlides(content) {
           slide.subBullets.get(parentIdx).push(subText);
           orderedNotesLines.push(`  • ${stripBold(subText)}`);
         }
+
+        const lastEl = slide.elements[slide.elements.length - 1];
+        if (lastEl && lastEl.type === 'bullet') {
+          if (!lastEl.subBullets) lastEl.subBullets = [];
+          lastEl.subBullets.push(subText);
+        }
+
+        if (currentItem) {
+          if (currentItem.year !== undefined) {
+            if (currentItem.summary) {
+              currentItem.summary += "\n" + subText;
+            } else {
+              currentItem.summary = subText;
+            }
+          }
+          if (!currentItem.summaryBullets) currentItem.summaryBullets = [];
+          currentItem.summaryBullets.push(subText);
+        }
         continue;
       }
 
@@ -116,15 +139,56 @@ function parseMarkdownToSlides(content) {
         const bulletText = bulletMatch[1].trim();
         slide.bullets.push(bulletText);
         orderedNotesLines.push(`• ${stripBold(bulletText)}`);
+
+        slide.elements.push({
+          type: 'bullet',
+          text: bulletText,
+          indentLevel: 0,
+          subBullets: []
+        });
+
+        const timelineMatch = bulletText.match(/^((?:19|20)\d{2}|[A-Za-z]{3}\s\d+|[A-Za-z]+)\s*[:-]\s*(.*)/);
+        if (timelineMatch) {
+          currentItem = { 
+            year: timelineMatch[1].trim(), 
+            title: timelineMatch[2].trim(), 
+            summary: "",
+            summaryBullets: []
+          };
+          items.push(currentItem);
+        } else {
+          if (!currentItem || currentItem.year !== undefined) {
+            currentItem = { title: "", summaryBullets: [] };
+            items.push(currentItem);
+          }
+          currentItem.summaryBullets.push(bulletText);
+        }
         continue;
       }
 
       if (trimmed.length > 0) {
         slide.bodyText.push(trimmed);
         orderedNotesLines.push(stripBold(trimmed));
+
+        slide.elements.push({
+          type: 'paragraph',
+          text: trimmed,
+          isLabel: trimmed.includes(':') && trimmed.length < 60,
+          isGoal: trimmed.toLowerCase().startsWith('goal:')
+        });
+
+        currentItem = { title: trimmed, summaryBullets: [] };
+        items.push(currentItem);
       }
     }
     if (inTable && tableHeaders.length > 0) slide.table = { headers: tableHeaders, rows: tableRows };
+
+    if (items.length > 0) {
+      slide.items = items.filter(item => {
+        if (item.year !== undefined) return true;
+        return item.title || (item.summaryBullets && item.summaryBullets.length > 0);
+      });
+    }
 
     if (speakerNotesLines.length > 0) {
       slide.speakerNotes = speakerNotesLines.join('\n');
@@ -377,4 +441,67 @@ Last Updated: June 22, 2026
   assert.equal(slides[1].title, 'Content Slide');
   assert.equal(slides[2].title, 'End Slide');
 });
+
+test('PPTX parsing: elements array preserves interleaved order and subbullets', () => {
+  const md = `
+## Interleaved Slide
+Why This Matters:
+- Bullet 1
+  - Sub 1
+- Bullet 2
+Second Header:
+- Bullet 3
+`;
+  const slides = parseMarkdownToSlides(md);
+  assert.equal(slides.length, 1);
+  const elements = slides[0].elements;
+  assert.equal(elements.length, 5);
+
+  assert.equal(elements[0].type, 'paragraph');
+  assert.equal(elements[0].text, 'Why This Matters:');
+
+  assert.equal(elements[1].type, 'bullet');
+  assert.equal(elements[1].text, 'Bullet 1');
+  assert.deepEqual(elements[1].subBullets, ['Sub 1']);
+
+  assert.equal(elements[2].type, 'bullet');
+  assert.equal(elements[2].text, 'Bullet 2');
+
+  assert.equal(elements[3].type, 'paragraph');
+  assert.equal(elements[3].text, 'Second Header:');
+
+  assert.equal(elements[4].type, 'bullet');
+  assert.equal(elements[4].text, 'Bullet 3');
+});
+
+test('PPTX parsing: items grouping maps columns and timelines fallback correctly', () => {
+  const md = `
+## Columns Slide
+**Layout: columns**
+MCP Server Monitoring
+- Monitor Model Context Protocol (MCP) servers
+- Track data flows through AI agent infrastructure
+
+Local AI Agent Discovery
+- Discover coding assistants and local AI tools
+- Inspect agent history and activity
+`;
+  const slides = parseMarkdownToSlides(md);
+  assert.equal(slides.length, 1);
+  const items = slides[0].items;
+  assert.equal(items.length, 2);
+
+  assert.equal(items[0].title, 'MCP Server Monitoring');
+  assert.deepEqual(items[0].summaryBullets, [
+    'Monitor Model Context Protocol (MCP) servers',
+    'Track data flows through AI agent infrastructure'
+  ]);
+
+  assert.equal(items[1].title, 'Local AI Agent Discovery');
+  assert.deepEqual(items[1].summaryBullets, [
+    'Discover coding assistants and local AI tools',
+    'Inspect agent history and activity'
+  ]);
+});
+
 

--- a/tests/presentation-layout.test.mjs
+++ b/tests/presentation-layout.test.mjs
@@ -2,87 +2,172 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 /**
- * Slide parsing logic shamelessly copied from src/lib/pptxExport.ts 
- * to verify regex stability and layout detection within the Node test runner.
+ * Slide parsing logic mirrored from src/lib/pptxExport.ts
+ * to verify regex stability, layout detection, and ordered notes
+ * within the Node test runner.
+ *
+ * Keep this in sync with the TypeScript source.
  */
-function parseMarkdownToSlides(content) {
-    const slides = [];
-    const lines = content.split('\n');
-    const sections = [];
-    let currentSection = null;
-
-    for (const line of lines) {
-        const trimmed = line.trim();
-        const h1Match = trimmed.match(/^#\s+(.+)/);
-        const h2Match = trimmed.match(/^##\s+(.+)/);
-        const slideMatch = trimmed.match(/^(?:#+\s*)?(?:\d+\.\s*)?Slide\s*\d*(?::|-)\s*(.*)/i);
-
-        if (h1Match) {
-            if (currentSection) sections.push(currentSection);
-            currentSection = { title: h1Match[1].trim(), lines: [], isMajor: true };
-        } else if (h2Match || slideMatch) {
-            if (currentSection) sections.push(currentSection);
-            const title = slideMatch ? slideMatch[1].trim() : h2Match[1].trim();
-            currentSection = { title: title || "Untitled", lines: [], isMajor: false };
-        } else if (trimmed === '---') {
-            if (currentSection) sections.push(currentSection);
-            currentSection = null;
-        } else if (currentSection) {
-            currentSection.lines.push(line);
-        }
-    }
-    if (currentSection) sections.push(currentSection);
-
-    for (const section of sections) {
-        const slide = { 
-            title: section.title, 
-            bullets: [], 
-            subBullets: new Map(), 
-            bodyText: [],
-            layoutHint: section.isMajor ? 'section' : undefined
-        };
-        
-        for (const line of section.lines) {
-            const trimmed = line.trim();
-            if (trimmed.length === 0) continue;
-
-            const layoutMatch = trimmed.match(/^\*\*\s*(?:Header|Layout)\s*[:\*]*\s*(.*?)(?:\*\*|$)/i);
-            if (layoutMatch) { 
-                const val = layoutMatch[1].toLowerCase().trim();
-                const valid = ['split', 'section', 'standard', 'comparison', 'columns', 'timeline', 'image', 'title'];
-                if (valid.includes(val)) slide.layoutHint = val;
-                continue; 
-            }
-
-            const bulletMatch = line.match(/^[-*]\s+(.*)/);
-            if (bulletMatch) { slide.bullets.push(bulletMatch[1].trim()); continue; }
-
-            if (trimmed.length > 0) slide.bodyText.push(trimmed);
-        }
-        slides.push(slide);
-    }
-    return slides;
+function stripBold(text) {
+  return text.replace(/\*\*(.*?)\*\*/g, '$1').trim();
 }
 
+function parseMarkdownToSlides(content) {
+  const slides = [];
+  const lines = content.split('\n');
+  const sections = [];
+  let currentSection = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    const h1Match = trimmed.match(/^#\s+(.+)/);
+    const h2Match = trimmed.match(/^##\s+(.+)/);
+    const slideMatch = trimmed.match(/^(?:#+\s*)?(?:\d+\.\s*)?Slide\s*\d*(?::|-)\s*(.*)/i);
+
+    if (h1Match) {
+      if (currentSection) sections.push(currentSection);
+      currentSection = { title: h1Match[1].trim(), lines: [], isMajor: true, startLine: i };
+    } else if (h2Match || slideMatch) {
+      if (currentSection) sections.push(currentSection);
+      const title = slideMatch ? slideMatch[1].trim() : h2Match[1].trim();
+      currentSection = { title: title || 'Untitled', lines: [], isMajor: false, startLine: i };
+    } else if (trimmed === '---') {
+      if (currentSection) sections.push(currentSection);
+      currentSection = null;
+    } else if (currentSection) {
+      currentSection.lines.push(line);
+    } else if (trimmed.length > 0) {
+      currentSection = { title: 'Introduction', lines: [line], isMajor: false, startLine: i };
+    }
+  }
+  if (currentSection) sections.push(currentSection);
+
+  for (const section of sections) {
+    const slide = {
+      title: section.title,
+      bullets: [],
+      subBullets: new Map(),
+      bodyText: [],
+      images: [],
+      layoutHint: section.isMajor ? 'section' : undefined,
+      startLine: section.startLine
+    };
+
+    let inTable = false, tableHeaders = [], tableRows = [];
+    let inSpeakerNotes = false, speakerNotesLines = [];
+    const orderedNotesLines = [];
+
+    for (const line of section.lines) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) { inSpeakerNotes = false; continue; }
+
+      const h3Match = trimmed.match(/^###\s+(.+)/);
+      if (h3Match) { slide.header = h3Match[1].trim(); continue; }
+      if (/^#+\s/.test(trimmed)) continue;
+
+      const headerMatch = trimmed.match(/^\*\*\s*(?:Header|Layout)\s*[:\*]*\s*(.*?)(?:\*\*|$)/i);
+      if (headerMatch) {
+        const val = headerMatch[1].toLowerCase().trim();
+        const valid = ['split', 'section', 'standard', 'comparison', 'columns', 'timeline', 'image', 'title'];
+        if (valid.includes(val)) slide.layoutHint = val;
+        else slide.header = stripBold(headerMatch[1]);
+        continue;
+      }
+
+      const notesMatch = trimmed.match(/^\*\*\s*Speaker Notes\s*[:\*]*\s*(.*)/i);
+      if (notesMatch) { inSpeakerNotes = true; if (notesMatch[1].trim()) speakerNotesLines.push(stripBold(notesMatch[1])); continue; }
+      if (inSpeakerNotes) { speakerNotesLines.push(trimmed); continue; }
+
+      const imageMatch = trimmed.match(/!\[(.*?)\]\((.*?)\)/);
+      if (imageMatch) {
+        slide.images.push({ alt: imageMatch[1], path: imageMatch[2] });
+        if (slide.images.length === 1 && slide.bullets.length === 0 && !slide.layoutHint) {
+          slide.layoutHint = 'image';
+        }
+        continue;
+      }
+
+      if (trimmed.startsWith('|')) {
+        if (/^\|[\s-:|]+\|$/.test(trimmed)) continue;
+        const cells = trimmed.split('|').slice(1, -1).map(c => c.trim());
+        if (!inTable) { inTable = true; tableHeaders = cells; } else tableRows.push(cells);
+        continue;
+      } else if (inTable) {
+        slide.table = { headers: tableHeaders, rows: tableRows };
+        inTable = false;
+      }
+
+      const subBulletMatch = line.match(/^(?:\s{2,}|\t)[-*]\s+(.*)/);
+      if (subBulletMatch) {
+        const parentIdx = slide.bullets.length - 1;
+        const subText = subBulletMatch[1].trim();
+        if (parentIdx >= 0) {
+          if (!slide.subBullets.has(parentIdx)) slide.subBullets.set(parentIdx, []);
+          slide.subBullets.get(parentIdx).push(subText);
+          orderedNotesLines.push(`  • ${stripBold(subText)}`);
+        }
+        continue;
+      }
+
+      const bulletMatch = line.match(/^[-*]\s+(.*)/);
+      if (bulletMatch) {
+        const bulletText = bulletMatch[1].trim();
+        slide.bullets.push(bulletText);
+        orderedNotesLines.push(`• ${stripBold(bulletText)}`);
+        continue;
+      }
+
+      if (trimmed.length > 0) {
+        slide.bodyText.push(trimmed);
+        orderedNotesLines.push(stripBold(trimmed));
+      }
+    }
+    if (inTable && tableHeaders.length > 0) slide.table = { headers: tableHeaders, rows: tableRows };
+
+    if (speakerNotesLines.length > 0) {
+      slide.speakerNotes = speakerNotesLines.join('\n');
+    } else if (orderedNotesLines.length > 0) {
+      slide.speakerNotes = orderedNotesLines.join('\n');
+    }
+    slide.fullText = slide.speakerNotes || '';
+
+    if (slide.bullets.length > 0 || slide.bodyText.length > 0 || slide.table || slide.header || slide.images.length > 0) {
+      slides.push(slide);
+    }
+  }
+  return slides;
+}
+
+// ─────────────────────────────────────────────────────────
+// Existing tests (kept)
+// ─────────────────────────────────────────────────────────
+
 test('PPTX: parseMarkdownToSlides handles different slide header formats', () => {
-    const md = `
+  const md = `
 # Title Slide
+- Title bullet
+
 ## Slide 1
+- Slide 1 bullet
+
 ---
+
 Slide 2: Summary
 ### Extra Header
 - Bullet 1
 `;
-    const slides = parseMarkdownToSlides(md);
-    assert.equal(slides.length, 3);
-    assert.equal(slides[0].title, 'Title Slide');
-    assert.equal(slides[0].layoutHint, 'section'); // H1 defaults to section in logic
-    assert.equal(slides[1].title, 'Slide 1');
-    assert.equal(slides[2].title, 'Summary');
+  const slides = parseMarkdownToSlides(md);
+  assert.equal(slides.length, 3, `Expected 3 slides, got ${slides.length}: ${slides.map(s => s.title).join(', ')}`);
+  assert.equal(slides[0].title, 'Title Slide');
+  assert.equal(slides[0].layoutHint, 'section'); // H1 defaults to section
+  assert.equal(slides[1].title, 'Slide 1');
+  assert.equal(slides[2].title, 'Summary');
 });
 
+
 test('PPTX: parseMarkdownToSlides detects layout overrides', () => {
-    const md = `
+  const md = `
 ## Features
 **Layout: columns**
 - Feature 1
@@ -93,17 +178,158 @@ test('PPTX: parseMarkdownToSlides detects layout overrides', () => {
 - Item A
 - Item B
 `;
-    const slides = parseMarkdownToSlides(md);
-    assert.equal(slides[0].layoutHint, 'columns');
-    assert.equal(slides[1].layoutHint, 'comparison');
+  const slides = parseMarkdownToSlides(md);
+  assert.equal(slides[0].layoutHint, 'columns');
+  assert.equal(slides[1].layoutHint, 'comparison');
 });
 
 test('PPTX: parseMarkdownToSlides handles loose layout formatting', () => {
-    const md = `
+  const md = `
 ## Modern View
 **Layout: SPLIT**
 Some text
 `;
-    const slides = parseMarkdownToSlides(md);
-    assert.equal(slides[0].layoutHint, 'split');
+  const slides = parseMarkdownToSlides(md);
+  assert.equal(slides[0].layoutHint, 'split');
+});
+
+// ─────────────────────────────────────────────────────────
+// New tests — content ordering and notes correctness
+// ─────────────────────────────────────────────────────────
+
+test('PPTX ordering: speakerNotes preserves interleaved bodyText + bullets in document order', () => {
+  // This reproduces the scrambled-notes bug: if the old code ran, notes would be
+  // "Intro paragraph\nConclusion paragraph\n• First bullet\n• Second bullet"
+  // (all bodyText grouped before all bullets). The fix should give:
+  // "Intro paragraph\n• First bullet\n• Second bullet\nConclusion paragraph"
+  const md = `
+## Strategic Themes Overview
+
+Intro paragraph
+
+- First bullet
+- Second bullet
+
+Conclusion paragraph
+`;
+  const slides = parseMarkdownToSlides(md);
+  assert.equal(slides.length, 1);
+  const notes = slides[0].speakerNotes;
+
+  // Verify order: intro comes before bullets, bullets come before conclusion
+  const introPos = notes.indexOf('Intro paragraph');
+  const bullet1Pos = notes.indexOf('First bullet');
+  const bullet2Pos = notes.indexOf('Second bullet');
+  const conclusionPos = notes.indexOf('Conclusion paragraph');
+
+  assert.ok(introPos !== -1, 'Notes should contain intro paragraph');
+  assert.ok(bullet1Pos !== -1, 'Notes should contain first bullet');
+  assert.ok(bullet2Pos !== -1, 'Notes should contain second bullet');
+  assert.ok(conclusionPos !== -1, 'Notes should contain conclusion paragraph');
+
+  assert.ok(introPos < bullet1Pos, 'Intro paragraph should appear before first bullet in notes');
+  assert.ok(bullet1Pos < bullet2Pos, 'First bullet should appear before second bullet in notes');
+  assert.ok(bullet2Pos < conclusionPos, 'Second bullet should appear before conclusion paragraph in notes');
+});
+
+test('PPTX ordering: sub-bullets appear after their parent bullet in notes', () => {
+  const md = `
+## Why This Matters
+
+Why This Matters:
+
+- 73% of enterprises deploying AI agents in 2026 (Forrester)
+  - Source: Forrester Q1 2026 report
+- Cyera acquired Ryft specifically for agentic AI security (May 2026)
+  - Deal valued at $1.2B
+`;
+  const slides = parseMarkdownToSlides(md);
+  assert.equal(slides.length, 1);
+
+  const notes = slides[0].speakerNotes;
+  const bodyPos = notes.indexOf('Why This Matters');
+  const bullet1Pos = notes.indexOf('73% of enterprises');
+  const sub1Pos = notes.indexOf('Forrester Q1 2026');
+  const bullet2Pos = notes.indexOf('Cyera acquired Ryft');
+  const sub2Pos = notes.indexOf('Deal valued');
+
+  assert.ok(bodyPos < bullet1Pos, 'Body text should appear before bullets');
+  assert.ok(bullet1Pos < sub1Pos, 'Parent bullet should appear before its sub-bullet');
+  assert.ok(sub1Pos < bullet2Pos, 'Sub-bullet of first bullet should appear before second bullet');
+  assert.ok(bullet2Pos < sub2Pos, 'Second parent bullet should appear before its sub-bullet');
+
+  // Sub-bullets should use indented marker
+  assert.ok(notes.includes('  •'), 'Sub-bullets should have indented bullet marker in notes');
+});
+
+test('PPTX ordering: explicit Speaker Notes block overrides auto-built notes', () => {
+  const md = `
+## Custom Notes Slide
+
+Some body text
+
+- A bullet
+
+**Speaker Notes:**
+This is the explicit notes content that should win.
+It should NOT be mixed with the body text or bullets.
+`;
+  const slides = parseMarkdownToSlides(md);
+  assert.equal(slides.length, 1);
+  const notes = slides[0].speakerNotes;
+
+  assert.ok(notes.includes('explicit notes content'), 'Explicit speaker notes should be used');
+  assert.ok(!notes.includes('Some body text'), 'Body text should NOT appear when explicit notes are present');
+  assert.ok(!notes.includes('A bullet'), 'Bullets should NOT appear when explicit notes are present');
+});
+
+test('PPTX ordering: multiple slides each get their own correctly ordered notes', () => {
+  const md = `
+## Slide A
+
+Intro A
+
+- Bullet A1
+- Bullet A2
+
+Closing A
+
+## Slide B
+
+Intro B
+
+- Bullet B1
+
+Closing B
+`;
+  const slides = parseMarkdownToSlides(md);
+  assert.equal(slides.length, 2);
+
+  const notesA = slides[0].speakerNotes;
+  const notesB = slides[1].speakerNotes;
+
+  // Slide A notes order
+  assert.ok(notesA.indexOf('Intro A') < notesA.indexOf('Bullet A1'), 'Slide A: Intro before bullet');
+  assert.ok(notesA.indexOf('Bullet A2') < notesA.indexOf('Closing A'), 'Slide A: Bullets before closing');
+
+  // Slide B notes order
+  assert.ok(notesB.indexOf('Intro B') < notesB.indexOf('Bullet B1'), 'Slide B: Intro before bullet');
+  assert.ok(notesB.indexOf('Bullet B1') < notesB.indexOf('Closing B'), 'Slide B: Bullet before closing');
+
+  // Notes should not bleed between slides
+  assert.ok(!notesA.includes('Intro B'), 'Slide A notes should not contain Slide B content');
+  assert.ok(!notesB.includes('Intro A'), 'Slide B notes should not contain Slide A content');
+});
+
+test('PPTX ordering: fullText mirrors speakerNotes exactly', () => {
+  const md = `
+## Mirror Test
+
+Body text here
+
+- Bullet one
+`;
+  const slides = parseMarkdownToSlides(md);
+  assert.equal(slides.length, 1);
+  assert.equal(slides[0].fullText, slides[0].speakerNotes, 'fullText should equal speakerNotes');
 });

--- a/tests/presentation-layout.test.mjs
+++ b/tests/presentation-layout.test.mjs
@@ -38,7 +38,8 @@ function parseMarkdownToSlides(content) {
     } else if (currentSection) {
       currentSection.lines.push(line);
     } else if (trimmed.length > 0) {
-      currentSection = { title: 'Introduction', lines: [line], isMajor: false, startLine: i };
+      const defaultTitle = sections.length === 0 ? "Introduction" : "End Slide";
+      currentSection = { title: defaultTitle, lines: [line], isMajor: false, startLine: i };
     }
   }
   if (currentSection) sections.push(currentSection);
@@ -98,7 +99,7 @@ function parseMarkdownToSlides(content) {
         inTable = false;
       }
 
-      const subBulletMatch = line.match(/^(?:\s{2,}|\t)[-*]\s+(.*)/);
+      const subBulletMatch = line.match(/^(?:\s{2,}|\t)(?:[-*]|\d+\.)\s+(.*)/);
       if (subBulletMatch) {
         const parentIdx = slide.bullets.length - 1;
         const subText = subBulletMatch[1].trim();
@@ -110,7 +111,7 @@ function parseMarkdownToSlides(content) {
         continue;
       }
 
-      const bulletMatch = line.match(/^[-*]\s+(.*)/);
+      const bulletMatch = line.match(/^(?:[-*]|\d+\.)\s+(.*)/);
       if (bulletMatch) {
         const bulletText = bulletMatch[1].trim();
         slide.bullets.push(bulletText);
@@ -333,3 +334,47 @@ Body text here
   assert.equal(slides.length, 1);
   assert.equal(slides[0].fullText, slides[0].speakerNotes, 'fullText should equal speakerNotes');
 });
+
+test('PPTX parsing: numbered lists are recognized as bullets and sub-bullets', () => {
+  const md = `
+## Numbered Lists Slide
+
+1. First main item
+   1. First sub item
+   2. Second sub item
+2. Second main item
+`;
+  const slides = parseMarkdownToSlides(md);
+  assert.equal(slides.length, 1);
+  assert.equal(slides[0].bullets.length, 2);
+  assert.equal(slides[0].bullets[0], 'First main item');
+  assert.equal(slides[0].bullets[1], 'Second main item');
+
+  const subBullets0 = slides[0].subBullets.get(0);
+  assert.ok(subBullets0, 'Should have sub-bullets for first bullet');
+  assert.equal(subBullets0.length, 2);
+  assert.equal(subBullets0[0], 'First sub item');
+  assert.equal(subBullets0[1], 'Second sub item');
+});
+
+test('PPTX parsing: trailing text after delimiter defaults to End Slide', () => {
+  const md = `
+# Title slide
+- A title slide bullet
+
+---
+
+## Content Slide
+Some content here
+
+---
+Document Owner: Product Management
+Last Updated: June 22, 2026
+`;
+  const slides = parseMarkdownToSlides(md);
+  assert.equal(slides.length, 3);
+  assert.equal(slides[0].title, 'Title slide');
+  assert.equal(slides[1].title, 'Content Slide');
+  assert.equal(slides[2].title, 'End Slide');
+});
+

--- a/tests/presentation-layout.test.mjs
+++ b/tests/presentation-layout.test.mjs
@@ -75,7 +75,7 @@ function parseMarkdownToSlides(content) {
       const headerMatch = trimmed.match(/^\*\*\s*(?:Header|Layout)\s*[:\*]*\s*(.*?)(?:\*\*|$)/i);
       if (headerMatch) {
         const val = headerMatch[1].toLowerCase().trim();
-        const valid = ['split', 'section', 'standard', 'comparison', 'columns', 'timeline', 'image', 'title'];
+        const valid = ['split', 'section', 'standard', 'comparison', 'columns', 'timeline', 'image', 'title', 'spotlight'];
         if (valid.includes(val)) slide.layoutHint = val;
         else slide.header = stripBold(headerMatch[1]);
         continue;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a spotlight-style PPTX slide layout for metric/caption content.
  * Enhanced exported slides with richer structure so bullets, paragraphs, and nested sub-bullets render more faithfully.
* **Bug Fixes**
  * Fixed PPTX export reordering by preserving original reading order for body text, bullets, and nested sub-bullets.
  * Fixed speaker notes and slide full text drifting by keeping them synchronized end-to-end.
  * Ensured explicit “Speaker Notes” blocks override auto-generated notes in exported results.
* **Tests**
  * Expanded layout and ordering coverage, including per-slide isolation and full-text mirroring.
* **Documentation**
  * Added PRD and export-fix documentation covering acceptance criteria and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->