### PR TITLE
fix(provider): send full prompt to agy CLI instead of '-' placeholder

### DIFF
--- a/node-backend/lib/providers/google.mjs
+++ b/node-backend/lib/providers/google.mjs
@@ -56,7 +56,7 @@ export class GoogleCliProvider extends AIProvider {
     const isAgy = command.includes('agy');
     const cliDisplayName = isAgy ? 'Google Antigravity CLI (agy)' : 'Gemini CLI';
 
-    const args = ['--prompt', '-', '--output-format', 'text', '--dangerously-skip-permissions'];
+    const args = ['--prompt', input, '--output-format', 'text', '--dangerously-skip-permissions'];
     const isLegacyModel = !configuredModel || ['pro', 'gemini-2.0-flash', 'gemini-1.5-pro', 'gemini-1.5-flash', 'default'].includes(configuredModel);
     if (configuredModel && !isLegacyModel) {
       args.push('--model', configuredModel);

--- a/node-backend/lib/providers/google.mjs
+++ b/node-backend/lib/providers/google.mjs
@@ -3,6 +3,12 @@ import { checkCli, resolveCliCommand, getEnhancedEnv } from '../system.mjs';
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 
+const MAX_ARG_PROMPT_LENGTH = process.platform === 'win32' ? 24000 : 120000;
+
+function isAgyCommand(command) {
+  return path.basename(String(command || '')).toLowerCase().includes('agy');
+}
+
 const MODEL_NAME_TO_ID = {
   'gemini 3.6 flash (high)': 'gemini-3.6-flash-high',
   'gemini 3.6 flash (medium)': 'gemini-3.6-flash-medium',
@@ -27,7 +33,7 @@ export class GoogleCliProvider extends AIProvider {
 
   async displayName() {
     const command = await this.resolveCommand();
-    return command.includes('agy') ? 'Google Antigravity CLI (agy)' : 'Gemini CLI (gemini)';
+    return isAgyCommand(command) ? 'Google Antigravity CLI (agy)' : 'Gemini CLI (gemini)';
   }
 
   async resolveCommand() {
@@ -53,10 +59,17 @@ export class GoogleCliProvider extends AIProvider {
 
     const input = this.buildCliInput(request);
     const command = await this.resolveCommand();
-    const isAgy = command.includes('agy');
+    const isAgy = isAgyCommand(command);
     const cliDisplayName = isAgy ? 'Google Antigravity CLI (agy)' : 'Gemini CLI';
 
-    const args = ['--prompt', input, '--output-format', 'text', '--dangerously-skip-permissions'];
+    // agy currently treats `--prompt -` as a literal dash, while Gemini CLI
+    // supports stdin. Keep argv prompts scoped to agy and fail before hitting
+    // OS command-line limits with large project-context prompts.
+    if (isAgy && input.length > MAX_ARG_PROMPT_LENGTH) {
+      throw new Error(`${cliDisplayName} prompt is too large to pass safely as a command-line argument (${input.length} chars). Reduce project context or switch to a CLI/provider that supports stdin prompt input.`);
+    }
+
+    const args = ['--prompt', isAgy ? input : '-', '--output-format', 'text', '--dangerously-skip-permissions'];
     const isLegacyModel = !configuredModel || ['pro', 'gemini-2.0-flash', 'gemini-1.5-pro', 'gemini-1.5-flash', 'default'].includes(configuredModel);
     if (configuredModel && !isLegacyModel) {
       args.push('--model', configuredModel);
@@ -85,7 +98,9 @@ export class GoogleCliProvider extends AIProvider {
         });
 
         if (child.stdin) {
-          child.stdin.write(input);
+          if (!isAgy) {
+            child.stdin.write(input);
+          }
           child.stdin.end();
         }
 
@@ -149,7 +164,7 @@ export class GoogleCliProvider extends AIProvider {
 
   async listModels() {
     const command = await this.resolveCommand();
-    const isAgy = command.includes('agy');
+    const isAgy = isAgyCommand(command);
     if (!isAgy) {
       return ['gemini-2.0-flash', 'gemini-1.5-pro', 'gemini-1.5-flash'];
     }

--- a/node-backend/tests/google-provider.test.mjs
+++ b/node-backend/tests/google-provider.test.mjs
@@ -6,7 +6,7 @@ import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
 
 import { GoogleCliProvider, GeminiCliProvider } from '../lib/providers/google.mjs';
 
-test('Google CLI provider passes GEMINI_API_KEY to process environment', async (t) => {
+test('Google CLI provider passes GEMINI_API_KEY and sends Gemini prompts via stdin', async (t) => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'productos-google-provider-'));
   const origHome = process.env.HOME;
   const origProjectsDir = process.env.PROJECTS_DIR;
@@ -63,8 +63,58 @@ process.stdin.on('end', () => {
 
   const payload = JSON.parse(result.content);
   assert.strictEqual(payload.apiKey, 'test-gemini-key-123');
+  assert.deepStrictEqual(payload.args.slice(0, 2), ['--prompt', '-']);
+  assert(payload.promptInput.includes('Hello Google CLI'));
+});
+
+test('Google Antigravity provider passes short prompts via argv', async (t) => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'productos-agy-provider-'));
+  t.after(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  const fakeAgyScript = path.join(tempDir, 'fake-agy.js');
+  await writeFile(
+    fakeAgyScript,
+    `let stdinContent = '';
+process.stdin.on('data', (chunk) => { stdinContent += chunk; });
+process.stdin.on('end', () => {
+  process.stdout.write(JSON.stringify({
+    args: process.argv.slice(2),
+    promptInput: stdinContent
+  }));
+});
+`,
+  );
+
+  const fakeAgyPath = process.platform === 'win32'
+    ? path.join(tempDir, 'fake-agy.cmd')
+    : path.join(tempDir, 'fake-agy');
+  await writeFile(
+    fakeAgyPath,
+    process.platform === 'win32'
+      ? `@echo off\r\nnode "%~dp0fake-agy.js" %*\r\n`
+      : `#!/bin/sh\nexec node "$(dirname "$0")/fake-agy.js" "$@"\n`,
+  );
+  await chmod(fakeAgyPath, 0o755);
+
+  const provider = new GoogleCliProvider({ command: fakeAgyPath });
+  const result = await provider.chat({
+    messages: [{ role: 'user', content: 'HelloGoogleCLI' }],
+  });
+
+  const payload = JSON.parse(result.content);
   assert.strictEqual(payload.args[0], '--prompt');
-  assert(payload.args[1].includes('Hello Google CLI'));
+  assert.strictEqual(payload.args[1], 'HelloGoogleCLI');
+  assert.strictEqual(payload.promptInput, '');
+});
+
+test('Google Antigravity provider rejects prompts that exceed argv safety limits', async () => {
+  const provider = new GoogleCliProvider({ command: path.join(os.tmpdir(), process.platform === 'win32' ? 'fake-agy.cmd' : 'fake-agy') });
+  await assert.rejects(
+    () => provider.chat({ messages: [{ role: 'user', content: 'x'.repeat(130000) }] }),
+    /prompt is too large to pass safely as a command-line argument/
+  );
 });
 
 test('Google CLI provider produces friendly error for IneligibleTierError/UNSUPPORTED_CLIENT', async (t) => {

--- a/node-backend/tests/google-provider.test.mjs
+++ b/node-backend/tests/google-provider.test.mjs
@@ -63,8 +63,8 @@ process.stdin.on('end', () => {
 
   const payload = JSON.parse(result.content);
   assert.strictEqual(payload.apiKey, 'test-gemini-key-123');
-  assert.deepStrictEqual(payload.args.slice(0, 2), ['--prompt', '-']);
-  assert(payload.promptInput.includes('Hello Google CLI'));
+  assert.strictEqual(payload.args[0], '--prompt');
+  assert(payload.args[1].includes('Hello Google CLI'));
 });
 
 test('Google CLI provider produces friendly error for IneligibleTierError/UNSUPPORTED_CLIENT', async (t) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google CLI prompt handling for more reliable request processing.
  * Added safer handling for long prompts, preventing failed requests before processing begins.
  * Improved detection of Google CLI commands across different installation paths.
* **Tests**
  * Expanded coverage for prompt delivery, command detection, and oversized prompt rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->