### PR TITLE
chore: prepare v0.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.3] - 2026-08-01
+
+### Added
+- Added Silent Learner mode with local-first knowledge capture, semantic retrieval, memory packs, privacy controls, and health diagnostics.
+- Added an OKF context layer that generates product context files and steers agent prompts from project settings.
+- Added Google Antigravity (`agy`) support under the Google provider, including model discovery, auth guidance, and setup improvements.
+- Added workspace recovery/recent-file sorting improvements and PPTX export enhancements.
+
+### Changed
+- Optimized prompt/context injection to reduce redundant token usage.
+- Improved editor comments and revision handling for more targeted AI fixes.
+- Hardened provider CLI invocation, environment detection, and large-prompt handling.
+
+### Fixed
+- Fixed chat reset/abort lifecycle issues, stale context regeneration, artifact sidecar reconciliation, transcript import privacy boundaries, and multiple UI responsiveness issues.
+- Resolved dependency/security audit findings across frontend and backend dependencies.
+- Bumped version to 0.4.3 in package.json and package-lock.json.
+- Updated CREDITS.md to match the package.json version.
+
 ## [0.4.2] - 2026-06-04
 
 ### Changed

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -7,7 +7,7 @@ This repository **productOS** (https://github.com/AIResearchFactory/productOS) i
 ## Project
 
 - **Name:** productOS
-- **Version:** 0.4.2
+- **Version:** 0.4.3
 - **Repository:** https://github.com/AIResearchFactory/productOS
 - **Maintainers:** Avia Tam, Assaf Miron
 - **License:** Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "productos",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "productos",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-context-menu": "2.2.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "productos",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": false,
   "description": "Local-first AI-powered research command center for product management.",
   "author": "AIResearchFactory",


### PR DESCRIPTION
## Summary
- bump package version from 0.4.2 to 0.4.3
- update package-lock, CREDITS, and CHANGELOG for the release

## Verification
- npm test
- npm run build

After this merges, rerun the Release workflow with ersion_override=0.4.3 so it skips the protected-branch version commit and proceeds to publish/tag/release.