### PR TITLE
feat: add hybrid model router

### DIFF
--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -1,0 +1,107 @@
+# Model Routing
+
+ProductOS supports a backend `autoRouter` provider that routes AI requests between a local trained provider and a cloud/fallback provider. The router is deliberately policy-driven: product features describe the task and privacy posture, while the router chooses the provider.
+
+## Goals
+
+- Keep private workspace/repository context on a local model by default.
+- Allow cloud models for public or high-quality tasks when policy permits it.
+- Add bounded local latency so the UI does not hang on slow local inference.
+- Make fallback behavior explicit: no silent cloud exfiltration of sensitive data.
+- Attach routing metadata to responses for debugging, telemetry, and cost reporting.
+
+## Provider
+
+Set `activeProvider` to `autoRouter` to enable routing.
+
+```json
+{
+  "activeProvider": "autoRouter",
+  "modelRouter": {
+    "enabled": true,
+    "mode": "auto",
+    "localProvider": "ollama",
+    "cloudProvider": "hostedApi",
+    "fallback": "cloudRedacted",
+    "localTimeoutMs": 3000,
+    "backgroundTimeoutMs": 15000,
+    "defaultPrivacyLevel": "workspace-private",
+    "logDecisions": true
+  }
+}
+```
+
+## Routing modes
+
+| Mode | Behavior |
+| --- | --- |
+| `auto` | Prefer local for workspace/private requests. For public requests, try local with cloud fallback. |
+| `privacyFirst` | Prefer local even when privacy metadata is missing. Cloud fallback only follows the configured fallback mode. |
+| `performanceFirst` | Use cloud first for public requests and local fallback. Private requests still go local first. |
+| `localOnly` | Always use the configured local provider. No fallback. |
+| `cloudOnly` | Always use the configured cloud provider. No fallback. |
+
+## Fallback modes
+
+| Fallback | Meaning |
+| --- | --- |
+| `none` | Do not fallback; return the local/cloud error. |
+| `cloud` | Send the original request to cloud. Only use this for data that is allowed to leave the machine. |
+| `cloudRedacted` | Redact obvious secrets/tokens/private-key blocks before cloud fallback. Default for private workspace routing. |
+| `askUser` | Fail with an approval-required message instead of sending to cloud. |
+| `local` | Used by cloud-first routes to fallback locally. |
+
+## Request traits
+
+The router currently resolves traits from request metadata and safe heuristics:
+
+- `privacyLevel` / `privacy_level`
+- `options.privacyLevel`
+- `options.task`
+- `options.priority`
+- presence of a project path or workspace/repository context
+- obvious secret/token/private-key patterns
+
+Recommended future call shape:
+
+```ts
+await modelRouter.generate({
+  task: 'code-review',
+  privacyLevel: 'repo-private',
+  priority: 'quality',
+  messages,
+});
+```
+
+## Latency policy
+
+- `localTimeoutMs` bounds foreground local attempts. Default: `3000ms`.
+- `backgroundTimeoutMs` bounds workflow/enrichment attempts. Default: `15000ms`.
+- The router overhead is deterministic and should be negligible compared with model inference.
+- If local inference times out and fallback is allowed, the response metadata records `fallbackUsed: true` and the fallback provider/model.
+
+## Response metadata
+
+Responses include `metadata.routing`:
+
+```json
+{
+  "router": "autoRouter",
+  "provider": "hostedApi",
+  "model": "gpt-4.1-mini",
+  "primaryProvider": "ollama",
+  "fallbackProvider": "hostedApi",
+  "fallbackUsed": true,
+  "fallbackRequest": "cloudRedacted",
+  "reason": "private-workspace-data",
+  "latencyMs": 4102,
+  "privacyLevel": "workspace-private",
+  "containsSecrets": false,
+  "local": false,
+  "cloud": true
+}
+```
+
+## Safety notes
+
+`cloudRedacted` is a safety backstop, not a formal DLP guarantee. Highly sensitive flows should use `localOnly` or `askUser` until a stronger classifier/redactor exists.

--- a/node-backend/lib/ai.mjs
+++ b/node-backend/lib/ai.mjs
@@ -4,6 +4,7 @@ import { GoogleCliProvider } from './providers/google.mjs';
 import { ClaudeCodeProvider } from './providers/claude.mjs';
 import { OpenAiCliProvider } from './providers/openai.mjs';
 import { CustomCliProvider } from './providers/custom.mjs';
+import { RoutedAIProvider } from './model-router.mjs';
 import { resolveCliCommand } from './system.mjs';
 import path from 'node:path';
 
@@ -31,6 +32,8 @@ export class AIService {
       'openAiCli',
       'openai_cli',
       'openai',
+      'autoRouter',
+      'auto_router',
     ]);
     if (builtInProviders.has(type)) return true;
 
@@ -60,6 +63,14 @@ export class AIService {
     const provider = await (async () => {
       const projectPath = settings.projectPath;
       switch (type) {
+        case 'autoRouter':
+        case 'auto_router':
+          return new RoutedAIProvider({
+            settings: { ...settings, projectPath },
+            secrets,
+            projectPath,
+            createProvider: (nextProviderType, nextSettings, nextSecrets) => AIService.createProvider(nextProviderType, nextSettings, nextSecrets),
+          });
         case 'ollama':
           return new OllamaProvider(mergeConfig(getCfg('ollama', 'ollama')), secrets, projectPath);
         case 'hostedApi':

--- a/node-backend/lib/ai.mjs
+++ b/node-backend/lib/ai.mjs
@@ -46,6 +46,29 @@ export class AIService {
     );
   }
 
+  static isCloudProvider(providerType, settings = {}) {
+    const type = String(providerType || '');
+    if (type === 'ollama') return false;
+
+    const customClis = settings.customClis || settings.custom_clis || [];
+    if (Array.isArray(customClis)) {
+      const custom = customClis.find(c =>
+        c.id === type ||
+        `custom-${c.id}` === type ||
+        c.name === type ||
+        `custom-${c.name}` === type
+      );
+      if (custom) {
+        if (typeof custom.isCloud === 'boolean') return custom.isCloud;
+        if (type.startsWith('custom-local-') || custom.id?.startsWith('custom-local-') || custom.id?.includes('local')) {
+          return false;
+        }
+      }
+    }
+    if (type.startsWith('custom-local-')) return false;
+    return true;
+  }
+
   static async createProvider(providerType, settings = {}, secrets = {}) {
     const type = String(providerType || settings.activeProvider || settings.active_provider || '');
     const getCfg = (keyCamel, keySnake) => settings[keyCamel] || settings[keySnake] || {};

--- a/node-backend/lib/ai.mjs
+++ b/node-backend/lib/ai.mjs
@@ -69,7 +69,13 @@ export class AIService {
             settings: { ...settings, projectPath },
             secrets,
             projectPath,
-            createProvider: (nextProviderType, nextSettings, nextSecrets) => AIService.createProvider(nextProviderType, nextSettings, nextSecrets),
+            createProvider: (nextProviderType, nextSettings, nextSecrets) => {
+              const typeStr = String(nextProviderType || '');
+              if (typeStr === 'autoRouter' || typeStr === 'auto_router') {
+                throw new Error('Self-referential autoRouter provider loop detected');
+              }
+              return AIService.createProvider(nextProviderType, nextSettings, nextSecrets);
+            },
           });
         case 'ollama':
           return new OllamaProvider(mergeConfig(getCfg('ollama', 'ollama')), secrets, projectPath);

--- a/node-backend/lib/ai.mjs
+++ b/node-backend/lib/ai.mjs
@@ -1,3 +1,4 @@
+import { isCloudProviderId } from './providers/base.mjs';
 import { OllamaProvider } from './providers/ollama.mjs';
 import { HostedAPIProvider } from './providers/hosted.mjs';
 import { GoogleCliProvider } from './providers/google.mjs';
@@ -47,26 +48,7 @@ export class AIService {
   }
 
   static isCloudProvider(providerType, settings = {}) {
-    const type = String(providerType || '');
-    if (type === 'ollama') return false;
-
-    const customClis = settings.customClis || settings.custom_clis || [];
-    if (Array.isArray(customClis)) {
-      const custom = customClis.find(c =>
-        c.id === type ||
-        `custom-${c.id}` === type ||
-        c.name === type ||
-        `custom-${c.name}` === type
-      );
-      if (custom) {
-        if (typeof custom.isCloud === 'boolean') return custom.isCloud;
-        if (type.startsWith('custom-local-') || custom.id?.startsWith('custom-local-') || custom.id?.includes('local')) {
-          return false;
-        }
-      }
-    }
-    if (type.startsWith('custom-local-')) return false;
-    return true;
+    return isCloudProviderId(providerType, settings);
   }
 
   static async createProvider(providerType, settings = {}, secrets = {}) {

--- a/node-backend/lib/model-router.mjs
+++ b/node-backend/lib/model-router.mjs
@@ -16,6 +16,9 @@ const CLOUD_PROVIDER_IDS = new Set([
   'openai_cli',
   'openai',
   'liteLlm',
+  'customCli',
+  'custom_cli',
+  'custom',
 ]);
 
 const LOCAL_PROVIDER_IDS = new Set(['ollama']);
@@ -80,7 +83,10 @@ function routerSettings(settings = {}) {
 }
 
 function isCloudProvider(providerId) {
-  return CLOUD_PROVIDER_IDS.has(String(providerId || ''));
+  const id = String(providerId || '');
+  if (CLOUD_PROVIDER_IDS.has(id)) return true;
+  if (id.startsWith('custom-') || id.startsWith('custom_') || id.includes('custom')) return true;
+  return !isLocalProvider(id);
 }
 
 function isLocalProvider(providerId) {
@@ -88,7 +94,7 @@ function isLocalProvider(providerId) {
 }
 
 function isSensitiveText(text = '') {
-  return /(api[_-]?key|secret|token|password|private key|BEGIN [A-Z ]*PRIVATE KEY|\.env\b|ssh-rsa|ghp_[a-z0-9_]+)/i.test(text);
+  return /(api[_-]?key|secret|token|password|private key|BEGIN [A-Z ]*PRIVATE KEY|\.env\b|ssh-(rsa|ed25519|dss|ecdsa[a-z0-9-]*)|ghp_[a-z0-9_]+)/i.test(text);
 }
 
 function inferRequestTraits(request = {}, settings = {}) {
@@ -112,6 +118,8 @@ export function redactModelRequestForCloud(request = {}) {
     .replace(/(api[_-]?key|token|secret|password)(\s*[:=]\s*)[^\s\n]+/gi, '$1$2[REDACTED]')
     .replace(/ghp_[A-Za-z0-9_]+/g, '[REDACTED_GITHUB_TOKEN]')
     .replace(/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, '[REDACTED_PRIVATE_KEY]')
+    .replace(/\bprivate key\b/gi, '[REDACTED_PRIVATE_KEY]')
+    .replace(/ssh-(rsa|ed25519|dss|ecdsa[a-z0-9-]*)\s+[A-Za-z0-9+/=]+(\s+\S+)?/gi, '[REDACTED_SSH_KEY]')
     .replace(/([A-Za-z]:)?[\\/][^\n\r]*(\.env|id_rsa|id_ed25519)[^\n\r]*/gi, '[REDACTED_SECRET_PATH]');
 
   return {
@@ -127,6 +135,17 @@ export function resolveModelRoute({ request = {}, settings = {}, requestedProvid
   const config = routerSettings(settings);
   const traits = inferRequestTraits(request, settings);
   const privateData = hasPrivateData(traits);
+
+  if (config.enabled === false) {
+    return {
+      primary: config.cloudProvider,
+      fallback: null,
+      fallbackRequest: 'none',
+      reason: 'router-disabled',
+      traits,
+      timeoutMs: null,
+    };
+  }
 
   if (requestedProvider && requestedProvider !== 'autoRouter') {
     return {
@@ -148,7 +167,14 @@ export function resolveModelRoute({ request = {}, settings = {}, requestedProvid
   }
 
   if (config.mode === 'performanceFirst' && !privateData) {
-    return { primary: config.cloudProvider, fallback: config.localProvider, fallbackRequest: 'original', reason: 'performance-first-public-data', traits, timeoutMs: null };
+    return {
+      primary: config.cloudProvider,
+      fallback: config.localProvider,
+      fallbackRequest: 'original',
+      reason: 'performance-first-public-data',
+      traits,
+      timeoutMs: traits.isBackground ? config.backgroundTimeoutMs : config.localTimeoutMs,
+    };
   }
 
   if (privateData || config.mode === 'privacyFirst') {
@@ -216,6 +242,7 @@ export class RoutedAIProvider {
     this.projectPath = projectPath;
     this.createProvider = createProvider;
     this.lastDecision = null;
+    this.config = routerSettings(settings);
   }
 
   providerType() {
@@ -231,8 +258,13 @@ export class RoutedAIProvider {
   }
 
   async checkAuthentication() {
-    const config = routerSettings(this.settings);
-    const candidates = [...new Set([config.localProvider, config.cloudProvider].filter(Boolean))];
+    const config = this.config || routerSettings(this.settings);
+    const candidates = config.mode === 'localOnly'
+      ? [config.localProvider]
+      : config.mode === 'cloudOnly'
+        ? [config.cloudProvider]
+        : [...new Set([config.localProvider, config.cloudProvider].filter(Boolean))];
+
     for (const providerId of candidates) {
       try {
         const provider = await this.createProvider(providerId, this.settings, this.secrets);
@@ -245,13 +277,16 @@ export class RoutedAIProvider {
   }
 
   async listModels() {
-    const config = routerSettings(this.settings);
+    const config = this.config || routerSettings(this.settings);
     const provider = await this.createProvider(config.localProvider, this.settings, this.secrets);
     return provider.listModels();
   }
 
   async chat(request) {
     const decision = resolveModelRoute({ request, settings: this.settings, requestedProvider: 'autoRouter' });
+    if (this.config?.logDecisions) {
+      console.log(`[ModelRouter] Executing route decision: primary=${decision.primary}, fallback=${decision.fallback || 'none'}, reason=${decision.reason}`);
+    }
     return this.#chatWithDecision(request, decision);
   }
 

--- a/node-backend/lib/model-router.mjs
+++ b/node-backend/lib/model-router.mjs
@@ -1,0 +1,310 @@
+const CLOUD_PROVIDER_IDS = new Set([
+  'hostedApi',
+  'hosted',
+  'geminiCli',
+  'gemini_cli',
+  'googleCli',
+  'google_cli',
+  'google',
+  'googleAntigravity',
+  'google_antigravity',
+  'antigravity',
+  'claudeCode',
+  'claude_code',
+  'claude',
+  'openAiCli',
+  'openai_cli',
+  'openai',
+  'liteLlm',
+]);
+
+const LOCAL_PROVIDER_IDS = new Set(['ollama']);
+
+const DEFAULT_LOCAL_TIMEOUT_MS = 3000;
+const DEFAULT_BACKGROUND_TIMEOUT_MS = 15000;
+
+function normalizeMode(mode) {
+  switch (mode) {
+    case 'local-only':
+    case 'localOnly':
+      return 'localOnly';
+    case 'cloud-only':
+    case 'cloudOnly':
+      return 'cloudOnly';
+    case 'privacy-first':
+    case 'privacyFirst':
+      return 'privacyFirst';
+    case 'performance-first':
+    case 'performanceFirst':
+      return 'performanceFirst';
+    default:
+      return 'auto';
+  }
+}
+
+function normalizeFallback(fallback) {
+  switch (fallback) {
+    case 'cloud-redacted':
+    case 'cloudRedacted':
+      return 'cloudRedacted';
+    case 'ask-user':
+    case 'askUser':
+      return 'askUser';
+    case 'local':
+    case 'cloud':
+    case 'none':
+      return fallback;
+    default:
+      return 'cloudRedacted';
+  }
+}
+
+function routerSettings(settings = {}) {
+  const config = settings.modelRouter || settings.model_router || settings.autoRouter || settings.auto_router || {};
+  return {
+    enabled: config.enabled !== false,
+    mode: normalizeMode(config.mode || settings.modelRoutingMode),
+    localProvider: config.localProvider || config.local_provider || 'ollama',
+    cloudProvider: config.cloudProvider || config.cloud_provider || settings.fallbackProvider || 'hostedApi',
+    fallback: normalizeFallback(config.fallback || config.fallbackMode || config.fallback_mode),
+    localTimeoutMs: Number(config.localTimeoutMs || config.local_timeout_ms || DEFAULT_LOCAL_TIMEOUT_MS),
+    backgroundTimeoutMs: Number(config.backgroundTimeoutMs || config.background_timeout_ms || DEFAULT_BACKGROUND_TIMEOUT_MS),
+    defaultPrivacyLevel: config.defaultPrivacyLevel || config.default_privacy_level || 'workspace-private',
+    logDecisions: config.logDecisions !== false && config.log_decisions !== false,
+  };
+}
+
+function isCloudProvider(providerId) {
+  return CLOUD_PROVIDER_IDS.has(String(providerId || ''));
+}
+
+function isLocalProvider(providerId) {
+  return LOCAL_PROVIDER_IDS.has(String(providerId || '')) || String(providerId || '').startsWith('custom-local-');
+}
+
+function isSensitiveText(text = '') {
+  return /(api[_-]?key|secret|token|password|private key|BEGIN [A-Z ]*PRIVATE KEY|\.env\b|ssh-rsa|ghp_[a-z0-9_]+)/i.test(text);
+}
+
+function inferRequestTraits(request = {}, settings = {}) {
+  const messages = Array.isArray(request.messages) ? request.messages : [];
+  const text = [request.system_prompt || '', ...messages.map((m) => m?.content || '')].join('\n');
+  const task = request.task || request.options?.task || 'chat';
+  const priority = request.priority || request.options?.priority || 'quality';
+  const privacyLevel = request.privacyLevel || request.privacy_level || request.options?.privacyLevel || routerSettings(settings).defaultPrivacyLevel;
+  const touchesWorkspace = Boolean(settings.projectPath || /project context|workspace|repository|repo-private|file tree/i.test(text));
+  const containsSecrets = isSensitiveText(text);
+  const isBackground = request.options?.background === true || request.background === true || task === 'workflow' || task === 'enrichment';
+  return { task, priority, privacyLevel, touchesWorkspace, containsSecrets, isBackground };
+}
+
+function hasPrivateData(traits) {
+  return traits.containsSecrets || ['secret', 'user-secret', 'repo-private', 'workspace-private', 'private'].includes(String(traits.privacyLevel || '')) || traits.touchesWorkspace;
+}
+
+export function redactModelRequestForCloud(request = {}) {
+  const redactText = (value = '') => String(value)
+    .replace(/(api[_-]?key|token|secret|password)(\s*[:=]\s*)[^\s\n]+/gi, '$1$2[REDACTED]')
+    .replace(/ghp_[A-Za-z0-9_]+/g, '[REDACTED_GITHUB_TOKEN]')
+    .replace(/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, '[REDACTED_PRIVATE_KEY]')
+    .replace(/([A-Za-z]:)?[\\/][^\n\r]*(\.env|id_rsa|id_ed25519)[^\n\r]*/gi, '[REDACTED_SECRET_PATH]');
+
+  return {
+    ...request,
+    system_prompt: request.system_prompt ? redactText(request.system_prompt) : request.system_prompt,
+    messages: Array.isArray(request.messages)
+      ? request.messages.map((message) => ({ ...message, content: redactText(message.content || '') }))
+      : request.messages,
+  };
+}
+
+export function resolveModelRoute({ request = {}, settings = {}, requestedProvider } = {}) {
+  const config = routerSettings(settings);
+  const traits = inferRequestTraits(request, settings);
+  const privateData = hasPrivateData(traits);
+
+  if (requestedProvider && requestedProvider !== 'autoRouter') {
+    return {
+      primary: requestedProvider,
+      fallback: null,
+      fallbackRequest: 'none',
+      reason: 'explicit-provider',
+      traits,
+      timeoutMs: null,
+    };
+  }
+
+  if (config.mode === 'localOnly') {
+    return { primary: config.localProvider, fallback: null, fallbackRequest: 'none', reason: 'local-only-mode', traits, timeoutMs: null };
+  }
+
+  if (config.mode === 'cloudOnly') {
+    return { primary: config.cloudProvider, fallback: null, fallbackRequest: 'none', reason: 'cloud-only-mode', traits, timeoutMs: null };
+  }
+
+  if (config.mode === 'performanceFirst' && !privateData) {
+    return { primary: config.cloudProvider, fallback: config.localProvider, fallbackRequest: 'original', reason: 'performance-first-public-data', traits, timeoutMs: null };
+  }
+
+  if (privateData || config.mode === 'privacyFirst') {
+    const fallback = config.fallback === 'cloud' || config.fallback === 'cloudRedacted' ? config.cloudProvider : null;
+    return {
+      primary: config.localProvider,
+      fallback,
+      fallbackRequest: fallback ? config.fallback : 'none',
+      reason: privateData ? 'private-workspace-data' : 'privacy-first-mode',
+      traits,
+      timeoutMs: traits.isBackground ? config.backgroundTimeoutMs : config.localTimeoutMs,
+    };
+  }
+
+  return {
+    primary: config.localProvider,
+    fallback: config.cloudProvider,
+    fallbackRequest: 'original',
+    reason: 'auto-prefer-local',
+    traits,
+    timeoutMs: traits.isBackground ? config.backgroundTimeoutMs : config.localTimeoutMs,
+  };
+}
+
+function withTimeout(promise, timeoutMs, label, onTimeout) {
+  if (!timeoutMs || timeoutMs <= 0) return promise;
+  let timeout;
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      timeout = setTimeout(() => {
+        try { onTimeout?.(); } catch { /* best-effort abort */ }
+        reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+    }),
+  ]).finally(() => clearTimeout(timeout));
+}
+
+function requestWithTimeoutSignal(request, timeoutMs) {
+  if (!timeoutMs || timeoutMs <= 0) return { request, abort: null };
+
+  const controller = new AbortController();
+  const parentSignal = request.signal;
+  const abort = () => controller.abort();
+  if (parentSignal) {
+    if (parentSignal.aborted) controller.abort();
+    else parentSignal.addEventListener('abort', abort, { once: true });
+  }
+
+  const cleanup = () => parentSignal?.removeEventListener?.('abort', abort);
+  return {
+    request: { ...request, signal: controller.signal },
+    abort: () => {
+      cleanup();
+      controller.abort();
+    },
+    cleanup,
+  };
+}
+
+export class RoutedAIProvider {
+  constructor({ settings = {}, secrets = {}, projectPath, createProvider }) {
+    this.settings = settings;
+    this.secrets = secrets;
+    this.projectPath = projectPath;
+    this.createProvider = createProvider;
+    this.lastDecision = null;
+  }
+
+  providerType() {
+    return 'autoRouter';
+  }
+
+  async displayName() {
+    return 'Model Router';
+  }
+
+  async resolveModel() {
+    return this.lastDecision?.model || this.lastDecision?.provider || 'autoRouter';
+  }
+
+  async checkAuthentication() {
+    const config = routerSettings(this.settings);
+    const candidates = [...new Set([config.localProvider, config.cloudProvider].filter(Boolean))];
+    for (const providerId of candidates) {
+      try {
+        const provider = await this.createProvider(providerId, this.settings, this.secrets);
+        if (await provider.checkAuthentication().catch(() => false)) return true;
+      } catch {
+        // Try the next configured provider.
+      }
+    }
+    return false;
+  }
+
+  async listModels() {
+    const config = routerSettings(this.settings);
+    const provider = await this.createProvider(config.localProvider, this.settings, this.secrets);
+    return provider.listModels();
+  }
+
+  async chat(request) {
+    const decision = resolveModelRoute({ request, settings: this.settings, requestedProvider: 'autoRouter' });
+    return this.#chatWithDecision(request, decision);
+  }
+
+  async #chatWithDecision(request, decision) {
+    const startedAt = Date.now();
+    const primary = await this.createProvider(decision.primary, this.settings, this.secrets);
+    const primaryLabel = primary.displayName ? await primary.displayName() : decision.primary;
+
+    try {
+      const timedPrimary = requestWithTimeoutSignal(request, decision.timeoutMs);
+      const response = await withTimeout(
+        primary.chat(timedPrimary.request),
+        decision.timeoutMs,
+        primaryLabel,
+        timedPrimary.abort,
+      ).finally(() => timedPrimary.cleanup?.());
+      this.lastDecision = await this.#decisionMetadata(decision, primary, false, Date.now() - startedAt);
+      response.metadata = {
+        ...(response.metadata || {}),
+        routing: this.lastDecision,
+      };
+      return response;
+    } catch (error) {
+      if (!decision.fallback) throw error;
+      if (decision.fallbackRequest === 'askUser') {
+        throw new Error(`${primaryLabel} failed (${error.message}). Cloud fallback requires user approval for this request.`);
+      }
+
+      const fallbackRequest = decision.fallbackRequest === 'cloudRedacted'
+        ? redactModelRequestForCloud(request)
+        : request;
+      const fallback = await this.createProvider(decision.fallback, this.settings, this.secrets);
+      const response = await fallback.chat(fallbackRequest);
+      this.lastDecision = await this.#decisionMetadata(decision, fallback, true, Date.now() - startedAt, error);
+      response.metadata = {
+        ...(response.metadata || {}),
+        routing: this.lastDecision,
+      };
+      return response;
+    }
+  }
+
+  async #decisionMetadata(decision, provider, fallbackUsed, latencyMs, error = null) {
+    return {
+      router: 'autoRouter',
+      provider: provider.providerType(),
+      model: await provider.resolveModel().catch(() => provider.providerType()),
+      primaryProvider: decision.primary,
+      fallbackProvider: decision.fallback,
+      fallbackUsed,
+      fallbackRequest: fallbackUsed ? decision.fallbackRequest : 'none',
+      reason: decision.reason,
+      latencyMs,
+      error: error ? error.message : undefined,
+      privacyLevel: decision.traits?.privacyLevel,
+      containsSecrets: Boolean(decision.traits?.containsSecrets),
+      local: isLocalProvider(provider.providerType()),
+      cloud: isCloudProvider(provider.providerType()),
+    };
+  }
+}

--- a/node-backend/lib/model-router.mjs
+++ b/node-backend/lib/model-router.mjs
@@ -1,27 +1,4 @@
-const CLOUD_PROVIDER_IDS = new Set([
-  'hostedApi',
-  'hosted',
-  'geminiCli',
-  'gemini_cli',
-  'googleCli',
-  'google_cli',
-  'google',
-  'googleAntigravity',
-  'google_antigravity',
-  'antigravity',
-  'claudeCode',
-  'claude_code',
-  'claude',
-  'openAiCli',
-  'openai_cli',
-  'openai',
-  'liteLlm',
-  'customCli',
-  'custom_cli',
-  'custom',
-]);
-
-const LOCAL_PROVIDER_IDS = new Set(['ollama']);
+import { isCloudProviderId } from './providers/base.mjs';
 
 const DEFAULT_LOCAL_TIMEOUT_MS = 3000;
 const DEFAULT_BACKGROUND_TIMEOUT_MS = 15000;
@@ -83,24 +60,11 @@ function routerSettings(settings = {}) {
 }
 
 function isCloudProvider(providerId, settings = {}) {
-  const id = String(providerId || '');
-  if (id === 'ollama') return false;
-  if (id.startsWith('custom-local-')) return false;
-  if (CLOUD_PROVIDER_IDS.has(id)) return true;
-  const customClis = settings.customClis || settings.custom_clis || [];
-  if (Array.isArray(customClis)) {
-    const custom = customClis.find(c => c.id === id || `custom-${c.id}` === id || c.name === id || `custom-${c.name}` === id);
-    if (custom) {
-      if (typeof custom.isCloud === 'boolean') return custom.isCloud;
-      if (custom.id?.startsWith('custom-local-') || custom.id?.includes('local')) return false;
-    }
-  }
-  if (id.startsWith('custom-') || id.startsWith('custom_') || id.includes('custom')) return true;
-  return !LOCAL_PROVIDER_IDS.has(id);
+  return isCloudProviderId(providerId, settings);
 }
 
 function isLocalProvider(providerId, settings = {}) {
-  return !isCloudProvider(providerId, settings);
+  return !isCloudProviderId(providerId, settings);
 }
 
 function isSensitiveText(text = '') {

--- a/node-backend/lib/model-router.mjs
+++ b/node-backend/lib/model-router.mjs
@@ -82,15 +82,25 @@ function routerSettings(settings = {}) {
   };
 }
 
-function isCloudProvider(providerId) {
+function isCloudProvider(providerId, settings = {}) {
   const id = String(providerId || '');
+  if (id === 'ollama') return false;
+  if (id.startsWith('custom-local-')) return false;
   if (CLOUD_PROVIDER_IDS.has(id)) return true;
+  const customClis = settings.customClis || settings.custom_clis || [];
+  if (Array.isArray(customClis)) {
+    const custom = customClis.find(c => c.id === id || `custom-${c.id}` === id || c.name === id || `custom-${c.name}` === id);
+    if (custom) {
+      if (typeof custom.isCloud === 'boolean') return custom.isCloud;
+      if (custom.id?.startsWith('custom-local-') || custom.id?.includes('local')) return false;
+    }
+  }
   if (id.startsWith('custom-') || id.startsWith('custom_') || id.includes('custom')) return true;
-  return !isLocalProvider(id);
+  return !LOCAL_PROVIDER_IDS.has(id);
 }
 
-function isLocalProvider(providerId) {
-  return LOCAL_PROVIDER_IDS.has(String(providerId || '')) || String(providerId || '').startsWith('custom-local-');
+function isLocalProvider(providerId, settings = {}) {
+  return !isCloudProvider(providerId, settings);
 }
 
 function isSensitiveText(text = '') {
@@ -330,6 +340,7 @@ export class RoutedAIProvider {
   }
 
   async #decisionMetadata(decision, provider, fallbackUsed, latencyMs, error = null) {
+    const isCloud = provider.isCloudProvider ? provider.isCloudProvider() : isCloudProvider(provider.providerType(), this.settings);
     return {
       router: 'autoRouter',
       provider: provider.providerType(),
@@ -343,8 +354,8 @@ export class RoutedAIProvider {
       error: error ? error.message : undefined,
       privacyLevel: decision.traits?.privacyLevel,
       containsSecrets: Boolean(decision.traits?.containsSecrets),
-      local: isLocalProvider(provider.providerType()),
-      cloud: isCloudProvider(provider.providerType()),
+      local: !isCloud,
+      cloud: isCloud,
     };
   }
 }

--- a/node-backend/lib/model-router.mjs
+++ b/node-backend/lib/model-router.mjs
@@ -59,13 +59,18 @@ function normalizeFallback(fallback) {
   }
 }
 
+function sanitizeProviderId(id, fallback) {
+  const type = String(id || '');
+  return (type === 'autoRouter' || type === 'auto_router') ? fallback : (id || fallback);
+}
+
 function routerSettings(settings = {}) {
   const config = settings.modelRouter || settings.model_router || settings.autoRouter || settings.auto_router || {};
   return {
     enabled: config.enabled !== false,
     mode: normalizeMode(config.mode || settings.modelRoutingMode),
-    localProvider: config.localProvider || config.local_provider || 'ollama',
-    cloudProvider: config.cloudProvider || config.cloud_provider || settings.fallbackProvider || 'hostedApi',
+    localProvider: sanitizeProviderId(config.localProvider || config.local_provider, 'ollama'),
+    cloudProvider: sanitizeProviderId(config.cloudProvider || config.cloud_provider || settings.fallbackProvider, 'hostedApi'),
     fallback: normalizeFallback(config.fallback || config.fallbackMode || config.fallback_mode),
     localTimeoutMs: Number(config.localTimeoutMs || config.local_timeout_ms || DEFAULT_LOCAL_TIMEOUT_MS),
     backgroundTimeoutMs: Number(config.backgroundTimeoutMs || config.background_timeout_ms || DEFAULT_BACKGROUND_TIMEOUT_MS),

--- a/node-backend/lib/model-router.mjs
+++ b/node-backend/lib/model-router.mjs
@@ -147,7 +147,7 @@ export function resolveModelRoute({ request = {}, settings = {}, requestedProvid
       fallbackRequest: 'original',
       reason: 'performance-first-public-data',
       traits,
-      timeoutMs: traits.isBackground ? config.backgroundTimeoutMs : config.localTimeoutMs,
+      timeoutMs: traits.isBackground ? config.backgroundTimeoutMs : null,
     };
   }
 

--- a/node-backend/lib/orchestrator.mjs
+++ b/node-backend/lib/orchestrator.mjs
@@ -20,6 +20,7 @@ function providerSetupGuidance(providerId, settings = {}, overrideLabel = null) 
     geminiCli: overrideLabel || 'Google Antigravity CLI (agy)',
     openAiCli: 'OpenAI CLI',
     liteLlm: 'LiteLLM',
+    autoRouter: 'Model Router',
   };
   const label = overrideLabel || labels[providerId] || providerId;
   const selected = Array.isArray(settings.selectedProviders) ? settings.selectedProviders : [];
@@ -34,6 +35,7 @@ function providerSetupGuidance(providerId, settings = {}, overrideLabel = null) 
     geminiCli: `Install ${label} and authenticate it, or add a Gemini API key in Settings → Models.`,
     openAiCli: 'Install Codex/OpenAI CLI and sign in, or add an OpenAI API key in Settings → Models.',
     liteLlm: 'Start your LiteLLM proxy and verify the base URL/API key in Settings → Models.',
+    autoRouter: 'Configure at least one local provider (Ollama) or cloud provider in Settings → Models, then keep Model Router in hybrid mode.',
   };
 
   return `The selected AI provider (${label}) is not ready, so chat cannot run yet.${selectedNote}\n\n${checks[providerId] || 'Open Settings → Models, verify this provider is installed/authenticated, or switch to another detected provider.'}`;

--- a/node-backend/lib/providers/base.mjs
+++ b/node-backend/lib/providers/base.mjs
@@ -29,6 +29,22 @@ export function spawnCli(spawnFunc, command, args = [], options = {}) {
   return child;
 }
 
+export function isCloudCustomCli(custom) {
+  if (!custom) return true;
+  if (typeof custom.isCloud === 'boolean') return custom.isCloud;
+  if (typeof custom.isLocal === 'boolean') return !custom.isLocal;
+
+  const id = String(custom.id || '');
+  const name = String(custom.name || '');
+
+  if (id.startsWith('custom-local-') || id.startsWith('local-') || id === 'local') return false;
+
+  const tokens = [...id.split(/[-_\s/]+/), ...name.split(/[-_\s/]+/)].map((t) => t.toLowerCase());
+  if (tokens.includes('local')) return false;
+
+  return true;
+}
+
 export function isCloudProviderId(providerId, settings = {}) {
   const type = String(providerId || '');
   if (type === 'ollama' || type.startsWith('custom-local-')) return false;
@@ -42,8 +58,7 @@ export function isCloudProviderId(providerId, settings = {}) {
       `custom-${c.name}` === type
     );
     if (custom) {
-      if (typeof custom.isCloud === 'boolean') return custom.isCloud;
-      if (custom.id?.startsWith('custom-local-') || custom.id?.includes('local')) return false;
+      return isCloudCustomCli(custom);
     }
   }
   return true;

--- a/node-backend/lib/providers/base.mjs
+++ b/node-backend/lib/providers/base.mjs
@@ -101,6 +101,10 @@ export class AIProvider {
     return true;
   }
 
+  isCloudProvider() {
+    return true;
+  }
+
   async checkAuthentication() {
     return true;
   }

--- a/node-backend/lib/providers/base.mjs
+++ b/node-backend/lib/providers/base.mjs
@@ -29,6 +29,26 @@ export function spawnCli(spawnFunc, command, args = [], options = {}) {
   return child;
 }
 
+export function isCloudProviderId(providerId, settings = {}) {
+  const type = String(providerId || '');
+  if (type === 'ollama' || type.startsWith('custom-local-')) return false;
+
+  const customClis = settings.customClis || settings.custom_clis || [];
+  if (Array.isArray(customClis)) {
+    const custom = customClis.find(c =>
+      c.id === type ||
+      `custom-${c.id}` === type ||
+      c.name === type ||
+      `custom-${c.name}` === type
+    );
+    if (custom) {
+      if (typeof custom.isCloud === 'boolean') return custom.isCloud;
+      if (custom.id?.startsWith('custom-local-') || custom.id?.includes('local')) return false;
+    }
+  }
+  return true;
+}
+
 export class AIProvider {
   /**
    * Build a single text block from a chat request suitable for CLI-based providers.

--- a/node-backend/lib/providers/custom.mjs
+++ b/node-backend/lib/providers/custom.mjs
@@ -1,4 +1,4 @@
-import { AIProvider, spawnCli } from './base.mjs';
+import { AIProvider, spawnCli, isCloudCustomCli } from './base.mjs';
 import { spawn } from 'node:child_process';
 
 export class CustomCliProvider extends AIProvider {
@@ -84,14 +84,7 @@ export class CustomCliProvider extends AIProvider {
   }
 
   isCloudProvider() {
-    if (typeof this.config?.isCloud === 'boolean') {
-      return this.config.isCloud;
-    }
-    const id = String(this.config?.id || '');
-    if (id.startsWith('custom-local-') || id.includes('local')) {
-      return false;
-    }
-    return true;
+    return isCloudCustomCli(this.config);
   }
 
   metadata() {

--- a/node-backend/lib/providers/custom.mjs
+++ b/node-backend/lib/providers/custom.mjs
@@ -83,6 +83,17 @@ export class CustomCliProvider extends AIProvider {
     return this.config.id || 'customCli';
   }
 
+  isCloudProvider() {
+    if (typeof this.config?.isCloud === 'boolean') {
+      return this.config.isCloud;
+    }
+    const id = String(this.config?.id || '');
+    if (id.startsWith('custom-local-') || id.includes('local')) {
+      return false;
+    }
+    return true;
+  }
+
   metadata() {
     return {
       id: this.config.id || 'custom',

--- a/node-backend/lib/providers/ollama.mjs
+++ b/node-backend/lib/providers/ollama.mjs
@@ -236,6 +236,10 @@ export class OllamaProvider extends AIProvider {
     return 'ollama';
   }
 
+  isCloudProvider() {
+    return false;
+  }
+
   metadata() {
     return {
       id: 'ollama',

--- a/node-backend/tests/model-router.test.mjs
+++ b/node-backend/tests/model-router.test.mjs
@@ -1,15 +1,15 @@
-import fs from 'node:fs';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
 // Set HOME and PROJECTS_DIR before test imports/executions per project conventions
-const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'model-router-test-'));
+const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'model-router-test-'));
 process.env.HOME = tmpDir;
 process.env.PROJECTS_DIR = path.join(tmpDir, 'projects');
 
-import { resolveModelRoute, redactModelRequestForCloud, RoutedAIProvider } from '../lib/model-router.mjs';
+const { resolveModelRoute, redactModelRequestForCloud, RoutedAIProvider } = await import('../lib/model-router.mjs');
 
 function chatProvider(id, { delayMs = 0, fail = false, auth = true, content = id } = {}) {
   return {
@@ -81,7 +81,7 @@ test('model router sends public performance-first requests to cloud with local f
   assert.equal(route.primary, 'openAiCli');
   assert.equal(route.fallback, 'ollama');
   assert.equal(route.fallbackRequest, 'original');
-  assert.equal(route.timeoutMs, 3000);
+  assert.equal(route.timeoutMs, null);
 });
 
 test('cloud-redacted fallback removes obvious secrets, ssh keys, and private key mentions from messages and system prompt', () => {

--- a/node-backend/tests/model-router.test.mjs
+++ b/node-backend/tests/model-router.test.mjs
@@ -165,3 +165,30 @@ test('routed provider falls back after local timeout and annotates routing metad
   assert.equal(response.metadata.routing.fallbackUsed, true);
   assert.equal(response.metadata.routing.fallbackRequest, 'cloudRedacted');
 });
+
+test('AIService.isCloudProvider correctly identifies cloud vs local providers', async () => {
+  const { AIService } = await import('../lib/ai.mjs');
+  const { OllamaProvider } = await import('../lib/providers/ollama.mjs');
+  const { HostedAPIProvider } = await import('../lib/providers/hosted.mjs');
+  const { CustomCliProvider } = await import('../lib/providers/custom.mjs');
+
+  const ollama = new OllamaProvider({});
+  assert.equal(ollama.isCloudProvider(), false);
+
+  const hosted = new HostedAPIProvider({});
+  assert.equal(hosted.isCloudProvider(), true);
+
+  const customCloud = new CustomCliProvider({ id: 'my-cloud-cli', isCloud: true });
+  assert.equal(customCloud.isCloudProvider(), true);
+
+  const customLocal = new CustomCliProvider({ id: 'custom-local-llama', isCloud: false });
+  assert.equal(customLocal.isCloudProvider(), false);
+
+  assert.equal(AIService.isCloudProvider('ollama'), false);
+  assert.equal(AIService.isCloudProvider('hostedApi'), true);
+  assert.equal(AIService.isCloudProvider('claudeCode'), true);
+  assert.equal(AIService.isCloudProvider('geminiCli'), true);
+  assert.equal(AIService.isCloudProvider('openAiCli'), true);
+  assert.equal(AIService.isCloudProvider('my-custom-cli', { customClis: [{ id: 'my-custom-cli', isCloud: false }] }), false);
+});
+

--- a/node-backend/tests/model-router.test.mjs
+++ b/node-backend/tests/model-router.test.mjs
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveModelRoute, redactModelRequestForCloud, RoutedAIProvider } from '../lib/model-router.mjs';
+
+function chatProvider(id, { delayMs = 0, fail = false, content = id } = {}) {
+  return {
+    providerType: () => id,
+    displayName: async () => id,
+    resolveModel: async () => `${id}-model`,
+    checkAuthentication: async () => true,
+    listModels: async () => [`${id}-model`],
+    chat: async () => {
+      if (delayMs) await new Promise((resolve) => setTimeout(resolve, delayMs));
+      if (fail) throw new Error(`${id} failed`);
+      return { content, metadata: { model_used: `${id}-model`, tokens_in: 1, tokens_out: 1 } };
+    },
+  };
+}
+
+test('model router sends private workspace data to the local provider first', () => {
+  const route = resolveModelRoute({
+    request: {
+      messages: [{ role: 'user', content: 'Review this repository diff' }],
+    },
+    settings: {
+      projectPath: '/repo/productOS',
+      modelRouter: { localProvider: 'ollama', cloudProvider: 'hostedApi' },
+    },
+    requestedProvider: 'autoRouter',
+  });
+
+  assert.equal(route.primary, 'ollama');
+  assert.equal(route.fallback, 'hostedApi');
+  assert.equal(route.fallbackRequest, 'cloudRedacted');
+  assert.equal(route.reason, 'private-workspace-data');
+});
+
+test('model router honors explicit provider bypass', () => {
+  const route = resolveModelRoute({
+    request: { messages: [{ role: 'user', content: 'hello' }] },
+    settings: { modelRouter: { mode: 'privacyFirst' } },
+    requestedProvider: 'openAiCli',
+  });
+
+  assert.equal(route.primary, 'openAiCli');
+  assert.equal(route.fallback, null);
+  assert.equal(route.reason, 'explicit-provider');
+});
+
+test('model router sends public performance-first requests to cloud with local fallback', () => {
+  const route = resolveModelRoute({
+    request: {
+      privacyLevel: 'public',
+      messages: [{ role: 'user', content: 'Draft launch copy for public website' }],
+    },
+    settings: { modelRouter: { mode: 'performanceFirst', localProvider: 'ollama', cloudProvider: 'openAiCli' } },
+    requestedProvider: 'autoRouter',
+  });
+
+  assert.equal(route.primary, 'openAiCli');
+  assert.equal(route.fallback, 'ollama');
+  assert.equal(route.fallbackRequest, 'original');
+});
+
+test('cloud-redacted fallback removes obvious secrets from messages and system prompt', () => {
+  const redacted = redactModelRequestForCloud({
+    system_prompt: 'Use api_key=sk-test-secret and path C:/repo/.env',
+    messages: [{ role: 'user', content: 'token: ghp_abcdefghijklmnopqrstuvwxyz123456 password=hunter2' }],
+  });
+
+  assert.match(redacted.system_prompt, /api_key=\[REDACTED\]/);
+  assert.doesNotMatch(redacted.system_prompt, /sk-test-secret/);
+  assert.doesNotMatch(redacted.system_prompt, /\.env/);
+  assert.doesNotMatch(redacted.messages[0].content, /ghp_/);
+  assert.doesNotMatch(redacted.messages[0].content, /hunter2/);
+});
+
+test('routed provider falls back after local timeout and annotates routing metadata', async () => {
+  const providers = {
+    ollama: chatProvider('ollama', { delayMs: 50, content: 'local' }),
+    hostedApi: chatProvider('hostedApi', { content: 'cloud' }),
+  };
+
+  const provider = new RoutedAIProvider({
+    settings: {
+      projectPath: '/repo/private',
+      modelRouter: {
+        localProvider: 'ollama',
+        cloudProvider: 'hostedApi',
+        localTimeoutMs: 5,
+        fallback: 'cloudRedacted',
+      },
+    },
+    secrets: {},
+    projectPath: '/repo/private',
+    createProvider: async (id) => providers[id],
+  });
+
+  const response = await provider.chat({
+    messages: [{ role: 'user', content: 'Summarize repo with token=abc123' }],
+  });
+
+  assert.equal(response.content, 'cloud');
+  assert.equal(response.metadata.routing.provider, 'hostedApi');
+  assert.equal(response.metadata.routing.primaryProvider, 'ollama');
+  assert.equal(response.metadata.routing.fallbackUsed, true);
+  assert.equal(response.metadata.routing.fallbackRequest, 'cloudRedacted');
+});

--- a/node-backend/tests/model-router.test.mjs
+++ b/node-backend/tests/model-router.test.mjs
@@ -1,13 +1,22 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
 import test from 'node:test';
 import assert from 'node:assert/strict';
+
+// Set HOME and PROJECTS_DIR before test imports/executions per project conventions
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'model-router-test-'));
+process.env.HOME = tmpDir;
+process.env.PROJECTS_DIR = path.join(tmpDir, 'projects');
+
 import { resolveModelRoute, redactModelRequestForCloud, RoutedAIProvider } from '../lib/model-router.mjs';
 
-function chatProvider(id, { delayMs = 0, fail = false, content = id } = {}) {
+function chatProvider(id, { delayMs = 0, fail = false, auth = true, content = id } = {}) {
   return {
     providerType: () => id,
     displayName: async () => id,
     resolveModel: async () => `${id}-model`,
-    checkAuthentication: async () => true,
+    checkAuthentication: async () => auth,
     listModels: async () => [`${id}-model`],
     chat: async () => {
       if (delayMs) await new Promise((resolve) => setTimeout(resolve, delayMs));
@@ -47,32 +56,82 @@ test('model router honors explicit provider bypass', () => {
   assert.equal(route.reason, 'explicit-provider');
 });
 
-test('model router sends public performance-first requests to cloud with local fallback', () => {
+test('model router respects enabled: false toggle', () => {
+  const route = resolveModelRoute({
+    request: { messages: [{ role: 'user', content: 'hello' }] },
+    settings: { modelRouter: { enabled: false, cloudProvider: 'hostedApi' } },
+    requestedProvider: 'autoRouter',
+  });
+
+  assert.equal(route.primary, 'hostedApi');
+  assert.equal(route.fallback, null);
+  assert.equal(route.reason, 'router-disabled');
+});
+
+test('model router sends public performance-first requests to cloud with local fallback and timeout', () => {
   const route = resolveModelRoute({
     request: {
       privacyLevel: 'public',
       messages: [{ role: 'user', content: 'Draft launch copy for public website' }],
     },
-    settings: { modelRouter: { mode: 'performanceFirst', localProvider: 'ollama', cloudProvider: 'openAiCli' } },
+    settings: { modelRouter: { mode: 'performanceFirst', localProvider: 'ollama', cloudProvider: 'openAiCli', localTimeoutMs: 3000 } },
     requestedProvider: 'autoRouter',
   });
 
   assert.equal(route.primary, 'openAiCli');
   assert.equal(route.fallback, 'ollama');
   assert.equal(route.fallbackRequest, 'original');
+  assert.equal(route.timeoutMs, 3000);
 });
 
-test('cloud-redacted fallback removes obvious secrets from messages and system prompt', () => {
+test('cloud-redacted fallback removes obvious secrets, ssh keys, and private key mentions from messages and system prompt', () => {
   const redacted = redactModelRequestForCloud({
-    system_prompt: 'Use api_key=sk-test-secret and path C:/repo/.env',
-    messages: [{ role: 'user', content: 'token: ghp_abcdefghijklmnopqrstuvwxyz123456 password=hunter2' }],
+    system_prompt: 'Use api_key=sk-test-secret, private key block, and path C:/repo/.env',
+    messages: [{ role: 'user', content: 'token: ghp_abcdefghijklmnopqrstuvwxyz123456 password=hunter2 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC user@host' }],
   });
 
   assert.match(redacted.system_prompt, /api_key=\[REDACTED\]/);
   assert.doesNotMatch(redacted.system_prompt, /sk-test-secret/);
   assert.doesNotMatch(redacted.system_prompt, /\.env/);
+  assert.match(redacted.system_prompt, /\[REDACTED_PRIVATE_KEY\]/);
   assert.doesNotMatch(redacted.messages[0].content, /ghp_/);
   assert.doesNotMatch(redacted.messages[0].content, /hunter2/);
+  assert.match(redacted.messages[0].content, /\[REDACTED_SSH_KEY\]/);
+  assert.doesNotMatch(redacted.messages[0].content, /AAAAB3NzaC1yc2E/);
+});
+
+test('RoutedAIProvider initializes config property for auth caching', () => {
+  const provider = new RoutedAIProvider({
+    settings: { modelRouter: { localProvider: 'ollama', cloudProvider: 'hostedApi', mode: 'localOnly' } },
+  });
+
+  assert.ok(provider.config);
+  assert.equal(provider.config.localProvider, 'ollama');
+  assert.equal(provider.config.cloudProvider, 'hostedApi');
+  assert.equal(provider.config.mode, 'localOnly');
+});
+
+test('RoutedAIProvider checkAuthentication respects localOnly and cloudOnly modes', async () => {
+  const providers = {
+    ollama: chatProvider('ollama', { auth: false }),
+    hostedApi: chatProvider('hostedApi', { auth: true }),
+  };
+
+  const providerLocalOnly = new RoutedAIProvider({
+    settings: { modelRouter: { localProvider: 'ollama', cloudProvider: 'hostedApi', mode: 'localOnly' } },
+    createProvider: async (id) => providers[id],
+  });
+
+  const authLocalOnly = await providerLocalOnly.checkAuthentication();
+  assert.equal(authLocalOnly, false, 'localOnly should fail if only cloud provider authenticates');
+
+  const providerCloudOnly = new RoutedAIProvider({
+    settings: { modelRouter: { localProvider: 'ollama', cloudProvider: 'hostedApi', mode: 'cloudOnly' } },
+    createProvider: async (id) => providers[id],
+  });
+
+  const authCloudOnly = await providerCloudOnly.checkAuthentication();
+  assert.equal(authCloudOnly, true, 'cloudOnly should succeed when cloud provider authenticates');
 });
 
 test('routed provider falls back after local timeout and annotates routing metadata', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8760,9 +8760,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -9700,9 +9700,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15326,9 +15326,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15887,9 +15887,9 @@
       }
     },
     "node_modules/webdriver/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6702,9 +6702,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/api/contracts.ts
+++ b/src/api/contracts.ts
@@ -93,7 +93,7 @@ export interface ModelRouterConfig {
   fallback: ModelRouterFallback;
   localTimeoutMs: number;
   backgroundTimeoutMs: number;
-  defaultPrivacyLevel: 'public' | 'internal' | 'workspace-private' | 'repo-private' | 'secret' | string;
+  defaultPrivacyLevel: 'public' | 'internal' | 'workspace-private' | 'repo-private' | 'secret' | (string & {});
   logDecisions: boolean;
 }
 

--- a/src/api/contracts.ts
+++ b/src/api/contracts.ts
@@ -82,6 +82,21 @@ export interface LiteLlmConfig {
   shadowMode: boolean;
 }
 
+export type ModelRouterMode = 'auto' | 'localOnly' | 'cloudOnly' | 'privacyFirst' | 'performanceFirst';
+export type ModelRouterFallback = 'none' | 'cloud' | 'cloudRedacted' | 'askUser' | 'local';
+
+export interface ModelRouterConfig {
+  enabled: boolean;
+  mode: ModelRouterMode;
+  localProvider: ProviderType;
+  cloudProvider: ProviderType;
+  fallback: ModelRouterFallback;
+  localTimeoutMs: number;
+  backgroundTimeoutMs: number;
+  defaultPrivacyLevel: 'public' | 'internal' | 'workspace-private' | 'repo-private' | 'secret' | string;
+  logDecisions: boolean;
+}
+
 export interface CustomCliConfig {
   id: string;
   name: string;
@@ -454,6 +469,7 @@ export interface GlobalSettings {
   geminiCli: GeminiCliConfig;
   openAiCli: OpenAiCliConfig;
   liteLlm: LiteLlmConfig;
+  modelRouter?: ModelRouterConfig;
   customClis: CustomCliConfig[];
   mcpServers: McpServerConfig[];
   artifactTemplates?: Record<string, string>;

--- a/src/api/contracts.ts
+++ b/src/api/contracts.ts
@@ -107,6 +107,7 @@ export interface CustomCliConfig {
   isConfigured: boolean;
   settingsFilePath?: string;
   mcpConfigFlag?: string;
+  isCloud?: boolean;
 }
 
 export interface McpServerConfig {

--- a/src/components/settings/ModelSettings.tsx
+++ b/src/components/settings/ModelSettings.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Cpu } from 'lucide-react';
+import { Cpu, ShieldCheck, Zap, AlertCircle, Lock, Radio } from 'lucide-react';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Input } from '@/components/ui/input';
-import { GlobalSettings } from '@/api/types';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { GlobalSettings, ModelRouterConfig, ModelRouterMode, ModelRouterFallback, ProviderType } from '@/api/contracts';
 
 interface ModelSettingsProps {
     settings: GlobalSettings;
@@ -12,20 +13,118 @@ interface ModelSettingsProps {
     setIsCustomModel: (v: boolean) => void;
 }
 
+const DEFAULT_ROUTER_CONFIG: ModelRouterConfig = {
+    enabled: true,
+    mode: 'auto',
+    localProvider: 'ollama',
+    cloudProvider: 'hostedApi',
+    fallback: 'cloudRedacted',
+    localTimeoutMs: 3000,
+    backgroundTimeoutMs: 15000,
+    defaultPrivacyLevel: 'workspace-private',
+    logDecisions: true,
+};
+
+const MODE_DESCRIPTIONS: Record<ModelRouterMode, { label: string; description: string; icon: React.ReactNode }> = {
+    auto: {
+        label: 'Auto (Intelligent Routing)',
+        description: 'Automatically balances speed, privacy, and quality. Uses local model for workspace data and cloud model for general queries.',
+        icon: <Cpu className="w-4 h-4 text-primary" />,
+    },
+    privacyFirst: {
+        label: 'Privacy First',
+        description: 'Prefers local models for all workspace queries. Only uses cloud fallback if configured and explicitly allowed.',
+        icon: <Lock className="w-4 h-4 text-green-500" />,
+    },
+    performanceFirst: {
+        label: 'Performance First',
+        description: 'Prefers high-performance cloud models for non-sensitive tasks for maximum response quality and speed.',
+        icon: <Zap className="w-4 h-4 text-amber-500" />,
+    },
+    localOnly: {
+        label: 'Local Only (Offline)',
+        description: 'Strictly routes all requests to local provider (e.g. Ollama). Data never leaves your machine.',
+        icon: <ShieldCheck className="w-4 h-4 text-blue-500" />,
+    },
+    cloudOnly: {
+        label: 'Cloud Only',
+        description: 'Strictly routes all requests to configured cloud provider. Fails if cloud provider is unreachable.',
+        icon: <Radio className="w-4 h-4 text-purple-500" />,
+    },
+};
+
+const FALLBACK_DESCRIPTIONS: Record<ModelRouterFallback, { label: string; description: string; badge?: string }> = {
+    cloudRedacted: {
+        label: 'Redacted Cloud Fallback (Recommended)',
+        description: 'If the preferred model is unavailable, fall back to cloud after automatically redacting API keys, secret tokens, and sensitive credentials.',
+        badge: 'Recommended',
+    },
+    cloud: {
+        label: 'Direct Cloud Fallback',
+        description: 'If preferred model is unavailable, fall back directly to cloud provider without prompt redaction.',
+    },
+    askUser: {
+        label: 'Require User Approval',
+        description: 'If preferred model is unavailable, pause execution and require explicit user approval before falling back to cloud.',
+    },
+    local: {
+        label: 'Local Model Fallback',
+        description: 'If preferred cloud provider fails, fall back to local provider.',
+    },
+    none: {
+        label: 'No Fallback (Fail Fast)',
+        description: 'Do not attempt fallback if preferred model is unavailable. Fail immediately with error.',
+    },
+};
+
 const ModelSettings: React.FC<ModelSettingsProps> = ({
     settings,
     setSettings,
     isCustomModel,
     setIsCustomModel
 }) => {
+    const routerConfig: ModelRouterConfig = {
+        ...DEFAULT_ROUTER_CONFIG,
+        ...(settings.modelRouter || {})
+    };
+
+    const updateRouterConfig = (updates: Partial<ModelRouterConfig>) => {
+        setSettings(prev => ({
+            ...prev,
+            modelRouter: {
+                ...DEFAULT_ROUTER_CONFIG,
+                ...(prev.modelRouter || {}),
+                ...updates
+            }
+        }));
+    };
+
+    // Gather available local and cloud providers
+    const customLocalClis = (settings.customClis || []).filter(c => c.isCloud === false);
+    const customCloudClis = (settings.customClis || []).filter(c => c.isCloud !== false);
+
+    const localProviders = [
+        { value: 'ollama', label: 'Ollama (Local Server)' },
+        ...customLocalClis.map(c => ({ value: c.id, label: `${c.name} (Custom Local)` }))
+    ];
+
+    const cloudProviders = [
+        { value: 'hostedApi', label: 'Hosted API' },
+        { value: 'claudeCode', label: 'Claude Code CLI' },
+        { value: 'geminiCli', label: 'Google / Antigravity CLI' },
+        { value: 'openAiCli', label: 'OpenAI / Codex CLI' },
+        ...customCloudClis.map(c => ({ value: c.id, label: `${c.name} (Custom Cloud)` }))
+    ];
+
     return (
         <div className="space-y-8 animate-in fade-in duration-500">
             <section className="space-y-6">
                 <div>
                     <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100 italic tracking-tight">Model Configuration</h3>
-                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">Configure default model identifiers and behavior across the platform</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">Configure default model identifiers and automated model routing behavior</p>
                 </div>
 
+                {/* Default Model Selection */}
                 <div className="space-y-4 pt-4 border-t border-gray-100 dark:border-gray-800">
                     <div className="flex items-center justify-between">
                         <Label htmlFor="default-model" className="text-sm font-medium">Default Model ID</Label>
@@ -50,19 +149,182 @@ const ModelSettings: React.FC<ModelSettingsProps> = ({
                             Enter exact model identifier. This ID is used across all research and workflow tasks.
                         </p>
                     </div>
+                </div>
 
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4">
-                        <div className="p-4 rounded-xl border border-gray-100 dark:border-gray-800 bg-gray-50/30 dark:bg-gray-900/30">
-                            <h4 className="text-sm font-semibold mb-2 flex items-center gap-2">
-                                <Cpu className="w-4 h-4 text-primary" />
-                                Model Routing
-                            </h4>
-                            <p className="text-xs text-muted-foreground">
-                                productOS automatically routes requests based on the capability of the selected provider. 
-                                Ensure your provider supports the model ID specified above.
+                {/* Model Routing Section */}
+                <div className="space-y-6 pt-6 border-t border-gray-100 dark:border-gray-800">
+                    <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2.5">
+                            <div className="p-2 rounded-xl bg-primary/10 text-primary">
+                                <Cpu className="w-5 h-5" />
+                            </div>
+                            <div>
+                                <h4 className="text-base font-semibold text-gray-900 dark:text-gray-100">Model Routing & Fallback</h4>
+                                <p className="text-xs text-muted-foreground">Manage execution modes and preferred fallback actions when models fail or are unreachable</p>
+                            </div>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <span className="text-xs text-muted-foreground font-medium">
+                                {routerConfig.enabled ? 'Enabled' : 'Disabled'}
+                            </span>
+                            <Switch
+                                checked={routerConfig.enabled}
+                                onCheckedChange={(enabled) => updateRouterConfig({ enabled })}
+                            />
+                        </div>
+                    </div>
+
+                    {/* Explanatory Banner */}
+                    <div className="p-4 rounded-xl border border-blue-500/20 bg-blue-500/5 dark:bg-blue-500/10 flex items-start gap-3">
+                        <AlertCircle className="w-5 h-5 text-blue-500 shrink-0 mt-0.5" />
+                        <div className="space-y-1 text-xs">
+                            <p className="font-semibold text-blue-900 dark:text-blue-200">
+                                How Model Routing Works
+                            </p>
+                            <p className="text-blue-700 dark:text-blue-300 leading-relaxed">
+                                Model Routing automatically handles situations where your preferred primary model is unavailable, rate-limited, timed out, or offline.
+                                Configure your preferred routing policy and fallback action below so productOS can maintain continuous operation.
                             </p>
                         </div>
                     </div>
+
+                    {routerConfig.enabled && (
+                        <div className="space-y-6 animate-in fade-in duration-300">
+                            {/* Routing Mode */}
+                            <div className="space-y-3">
+                                <Label className="text-xs font-semibold uppercase tracking-wider text-gray-500">Routing Mode</Label>
+                                <Select
+                                    value={routerConfig.mode}
+                                    onValueChange={(value: ModelRouterMode) => updateRouterConfig({ mode: value })}
+                                >
+                                    <SelectTrigger className="h-11 border-gray-200 dark:border-gray-800">
+                                        <SelectValue placeholder="Select Routing Mode" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {(Object.keys(MODE_DESCRIPTIONS) as ModelRouterMode[]).map((modeKey) => (
+                                            <SelectItem key={modeKey} value={modeKey}>
+                                                <div className="flex items-center gap-2 py-0.5">
+                                                    {MODE_DESCRIPTIONS[modeKey].icon}
+                                                    <span className="font-medium">{MODE_DESCRIPTIONS[modeKey].label}</span>
+                                                </div>
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <p className="text-xs text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-900/50 p-3 rounded-lg border border-gray-100 dark:border-gray-800">
+                                    {MODE_DESCRIPTIONS[routerConfig.mode]?.description}
+                                </p>
+                            </div>
+
+                            {/* Preferred Fallback Action */}
+                            <div className="space-y-3">
+                                <div className="flex items-center justify-between">
+                                    <Label className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+                                        Fallback Action (When Preferred Model Unresponsive)
+                                    </Label>
+                                </div>
+                                <Select
+                                    value={routerConfig.fallback}
+                                    onValueChange={(value: ModelRouterFallback) => updateRouterConfig({ fallback: value })}
+                                >
+                                    <SelectTrigger className="h-11 border-gray-200 dark:border-gray-800">
+                                        <SelectValue placeholder="Select Fallback Action" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {(Object.keys(FALLBACK_DESCRIPTIONS) as ModelRouterFallback[]).map((fallbackKey) => (
+                                            <SelectItem key={fallbackKey} value={fallbackKey}>
+                                                <div className="flex items-center justify-between w-full gap-3 py-0.5">
+                                                    <span className="font-medium">{FALLBACK_DESCRIPTIONS[fallbackKey].label}</span>
+                                                    {FALLBACK_DESCRIPTIONS[fallbackKey].badge && (
+                                                        <span className="bg-primary/10 text-primary text-[10px] px-2 py-0.5 rounded-full font-bold">
+                                                            {FALLBACK_DESCRIPTIONS[fallbackKey].badge}
+                                                        </span>
+                                                    )}
+                                                </div>
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <p className="text-xs text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-900/50 p-3 rounded-lg border border-gray-100 dark:border-gray-800">
+                                    {FALLBACK_DESCRIPTIONS[routerConfig.fallback]?.description}
+                                </p>
+                            </div>
+
+                            {/* Preferred Providers */}
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-2">
+                                <div className="space-y-2 p-4 rounded-xl border border-gray-100 dark:border-gray-800 bg-gray-50/30 dark:bg-gray-900/30">
+                                    <Label className="text-xs font-medium flex items-center gap-2">
+                                        <ShieldCheck className="w-4 h-4 text-green-500" />
+                                        Preferred Local Provider
+                                    </Label>
+                                    <Select
+                                        value={routerConfig.localProvider}
+                                        onValueChange={(value: ProviderType) => updateRouterConfig({ localProvider: value })}
+                                    >
+                                        <SelectTrigger className="h-9 text-xs border-gray-200 dark:border-gray-800 bg-background">
+                                            <SelectValue placeholder="Select Local Provider" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {localProviders.map(p => (
+                                                <SelectItem key={p.value} value={p.value}>{p.label}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                    <p className="text-[11px] text-muted-foreground">Used for offline execution and private workspace operations.</p>
+                                </div>
+
+                                <div className="space-y-2 p-4 rounded-xl border border-gray-100 dark:border-gray-800 bg-gray-50/30 dark:bg-gray-900/30">
+                                    <Label className="text-xs font-medium flex items-center gap-2">
+                                        <Zap className="w-4 h-4 text-amber-500" />
+                                        Preferred Cloud Provider
+                                    </Label>
+                                    <Select
+                                        value={routerConfig.cloudProvider}
+                                        onValueChange={(value: ProviderType) => updateRouterConfig({ cloudProvider: value })}
+                                    >
+                                        <SelectTrigger className="h-9 text-xs border-gray-200 dark:border-gray-800 bg-background">
+                                            <SelectValue placeholder="Select Cloud Provider" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {cloudProviders.map(p => (
+                                                <SelectItem key={p.value} value={p.value}>{p.label}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                    <p className="text-[11px] text-muted-foreground">Used for cloud queries and fallback when local model fails.</p>
+                                </div>
+                            </div>
+
+                            {/* Execution Timeout Settings */}
+                            <div className="space-y-3 pt-2">
+                                <Label className="text-xs font-semibold uppercase tracking-wider text-gray-500">Execution Timeout Thresholds</Label>
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <div className="space-y-1.5">
+                                        <Label className="text-2xs text-gray-500">Local Timeout (ms)</Label>
+                                        <Input
+                                            type="number"
+                                            value={routerConfig.localTimeoutMs}
+                                            onChange={(e) => updateRouterConfig({ localTimeoutMs: parseInt(e.target.value, 10) || 3000 })}
+                                            className="h-8 text-xs font-mono"
+                                            placeholder="3000"
+                                        />
+                                        <p className="text-[10px] text-gray-400">Time to wait for local model before triggering fallback.</p>
+                                    </div>
+                                    <div className="space-y-1.5">
+                                        <Label className="text-2xs text-gray-500">Background Task Timeout (ms)</Label>
+                                        <Input
+                                            type="number"
+                                            value={routerConfig.backgroundTimeoutMs}
+                                            onChange={(e) => updateRouterConfig({ backgroundTimeoutMs: parseInt(e.target.value, 10) || 15000 })}
+                                            className="h-8 text-xs font-mono"
+                                            placeholder="15000"
+                                        />
+                                        <p className="text-[10px] text-gray-400">Timeout threshold for background enrichment and knowledge tasks.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    )}
                 </div>
             </section>
         </div>
@@ -70,4 +332,3 @@ const ModelSettings: React.FC<ModelSettingsProps> = ({
 };
 
 export default ModelSettings;
-

--- a/src/components/settings/ModelSettings.tsx
+++ b/src/components/settings/ModelSettings.tsx
@@ -99,9 +99,19 @@ const ModelSettings: React.FC<ModelSettingsProps> = ({
         }));
     };
 
+    const isCustomCliCloud = (cli: { id: string; name?: string; isCloud?: boolean }) => {
+        if (typeof cli.isCloud === 'boolean') return cli.isCloud;
+        const id = (cli.id || '').toLowerCase();
+        const name = (cli.name || '').toLowerCase();
+        if (id.startsWith('custom-local-') || id.startsWith('local-') || id === 'local') return false;
+        const tokens = [...id.split(/[-_\s/]+/), ...name.split(/[-_\s/]+/)];
+        if (tokens.includes('local')) return false;
+        return true;
+    };
+
     // Gather available local and cloud providers
-    const customLocalClis = (settings.customClis || []).filter(c => c.isCloud === false);
-    const customCloudClis = (settings.customClis || []).filter(c => c.isCloud !== false);
+    const customLocalClis = (settings.customClis || []).filter(c => !isCustomCliCloud(c));
+    const customCloudClis = (settings.customClis || []).filter(c => isCustomCliCloud(c));
 
     const localProviders = [
         { value: 'ollama', label: 'Ollama (Local Server)' },
@@ -116,6 +126,11 @@ const ModelSettings: React.FC<ModelSettingsProps> = ({
         ...customCloudClis.map(c => ({ value: c.id, label: `${c.name} (Custom Cloud)` }))
     ];
 
+    const parseTimeoutValue = (val: string, fallback: number): number => {
+        const parsed = parseInt(val, 10);
+        return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+    };
+
     return (
         <div className="space-y-8 animate-in fade-in duration-500">
             <section className="space-y-6">
@@ -129,8 +144,9 @@ const ModelSettings: React.FC<ModelSettingsProps> = ({
                     <div className="flex items-center justify-between">
                         <Label htmlFor="default-model" className="text-sm font-medium">Default Model ID</Label>
                         <div className="flex items-center gap-2">
-                            <span className="text-xs text-gray-500">Custom ID</span>
+                            <Label htmlFor="custom-model-id-toggle" className="text-xs text-gray-500 cursor-pointer">Custom ID</Label>
                             <Switch
+                                id="custom-model-id-toggle"
                                 checked={isCustomModel}
                                 onCheckedChange={setIsCustomModel}
                             />
@@ -164,10 +180,11 @@ const ModelSettings: React.FC<ModelSettingsProps> = ({
                             </div>
                         </div>
                         <div className="flex items-center gap-2">
-                            <span className="text-xs text-muted-foreground font-medium">
+                            <Label htmlFor="model-routing-toggle" className="text-xs text-muted-foreground font-medium cursor-pointer">
                                 {routerConfig.enabled ? 'Enabled' : 'Disabled'}
-                            </span>
+                            </Label>
                             <Switch
+                                id="model-routing-toggle"
                                 checked={routerConfig.enabled}
                                 onCheckedChange={(enabled) => updateRouterConfig({ enabled })}
                             />
@@ -192,12 +209,12 @@ const ModelSettings: React.FC<ModelSettingsProps> = ({
                         <div className="space-y-6 animate-in fade-in duration-300">
                             {/* Routing Mode */}
                             <div className="space-y-3">
-                                <Label className="text-xs font-semibold uppercase tracking-wider text-gray-500">Routing Mode</Label>
+                                <Label htmlFor="routing-mode-select" className="text-xs font-semibold uppercase tracking-wider text-gray-500">Routing Mode</Label>
                                 <Select
                                     value={routerConfig.mode}
                                     onValueChange={(value: ModelRouterMode) => updateRouterConfig({ mode: value })}
                                 >
-                                    <SelectTrigger className="h-11 border-gray-200 dark:border-gray-800">
+                                    <SelectTrigger id="routing-mode-select" className="h-11 border-gray-200 dark:border-gray-800">
                                         <SelectValue placeholder="Select Routing Mode" />
                                     </SelectTrigger>
                                     <SelectContent>
@@ -219,7 +236,7 @@ const ModelSettings: React.FC<ModelSettingsProps> = ({
                             {/* Preferred Fallback Action */}
                             <div className="space-y-3">
                                 <div className="flex items-center justify-between">
-                                    <Label className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+                                    <Label htmlFor="fallback-action-select" className="text-xs font-semibold uppercase tracking-wider text-gray-500">
                                         Fallback Action (When Preferred Model Unresponsive)
                                     </Label>
                                 </div>
@@ -227,7 +244,7 @@ const ModelSettings: React.FC<ModelSettingsProps> = ({
                                     value={routerConfig.fallback}
                                     onValueChange={(value: ModelRouterFallback) => updateRouterConfig({ fallback: value })}
                                 >
-                                    <SelectTrigger className="h-11 border-gray-200 dark:border-gray-800">
+                                    <SelectTrigger id="fallback-action-select" className="h-11 border-gray-200 dark:border-gray-800">
                                         <SelectValue placeholder="Select Fallback Action" />
                                     </SelectTrigger>
                                     <SelectContent>
@@ -253,7 +270,7 @@ const ModelSettings: React.FC<ModelSettingsProps> = ({
                             {/* Preferred Providers */}
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-2">
                                 <div className="space-y-2 p-4 rounded-xl border border-gray-100 dark:border-gray-800 bg-gray-50/30 dark:bg-gray-900/30">
-                                    <Label className="text-xs font-medium flex items-center gap-2">
+                                    <Label htmlFor="preferred-local-provider" className="text-xs font-medium flex items-center gap-2">
                                         <ShieldCheck className="w-4 h-4 text-green-500" />
                                         Preferred Local Provider
                                     </Label>
@@ -261,7 +278,7 @@ const ModelSettings: React.FC<ModelSettingsProps> = ({
                                         value={routerConfig.localProvider}
                                         onValueChange={(value: ProviderType) => updateRouterConfig({ localProvider: value })}
                                     >
-                                        <SelectTrigger className="h-9 text-xs border-gray-200 dark:border-gray-800 bg-background">
+                                        <SelectTrigger id="preferred-local-provider" className="h-9 text-xs border-gray-200 dark:border-gray-800 bg-background">
                                             <SelectValue placeholder="Select Local Provider" />
                                         </SelectTrigger>
                                         <SelectContent>
@@ -274,7 +291,7 @@ const ModelSettings: React.FC<ModelSettingsProps> = ({
                                 </div>
 
                                 <div className="space-y-2 p-4 rounded-xl border border-gray-100 dark:border-gray-800 bg-gray-50/30 dark:bg-gray-900/30">
-                                    <Label className="text-xs font-medium flex items-center gap-2">
+                                    <Label htmlFor="preferred-cloud-provider" className="text-xs font-medium flex items-center gap-2">
                                         <Zap className="w-4 h-4 text-amber-500" />
                                         Preferred Cloud Provider
                                     </Label>
@@ -282,7 +299,7 @@ const ModelSettings: React.FC<ModelSettingsProps> = ({
                                         value={routerConfig.cloudProvider}
                                         onValueChange={(value: ProviderType) => updateRouterConfig({ cloudProvider: value })}
                                     >
-                                        <SelectTrigger className="h-9 text-xs border-gray-200 dark:border-gray-800 bg-background">
+                                        <SelectTrigger id="preferred-cloud-provider" className="h-9 text-xs border-gray-200 dark:border-gray-800 bg-background">
                                             <SelectValue placeholder="Select Cloud Provider" />
                                         </SelectTrigger>
                                         <SelectContent>
@@ -300,22 +317,28 @@ const ModelSettings: React.FC<ModelSettingsProps> = ({
                                 <Label className="text-xs font-semibold uppercase tracking-wider text-gray-500">Execution Timeout Thresholds</Label>
                                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                     <div className="space-y-1.5">
-                                        <Label className="text-2xs text-gray-500">Local Timeout (ms)</Label>
+                                        <Label htmlFor="local-timeout-ms" className="text-2xs text-gray-500">Local Timeout (ms)</Label>
                                         <Input
+                                            id="local-timeout-ms"
                                             type="number"
+                                            min={0}
+                                            step={100}
                                             value={routerConfig.localTimeoutMs}
-                                            onChange={(e) => updateRouterConfig({ localTimeoutMs: parseInt(e.target.value, 10) || 3000 })}
+                                            onChange={(e) => updateRouterConfig({ localTimeoutMs: parseTimeoutValue(e.target.value, 3000) })}
                                             className="h-8 text-xs font-mono"
                                             placeholder="3000"
                                         />
                                         <p className="text-[10px] text-gray-400">Time to wait for local model before triggering fallback.</p>
                                     </div>
                                     <div className="space-y-1.5">
-                                        <Label className="text-2xs text-gray-500">Background Task Timeout (ms)</Label>
+                                        <Label htmlFor="background-timeout-ms" className="text-2xs text-gray-500">Background Task Timeout (ms)</Label>
                                         <Input
+                                            id="background-timeout-ms"
                                             type="number"
+                                            min={0}
+                                            step={100}
                                             value={routerConfig.backgroundTimeoutMs}
-                                            onChange={(e) => updateRouterConfig({ backgroundTimeoutMs: parseInt(e.target.value, 10) || 15000 })}
+                                            onChange={(e) => updateRouterConfig({ backgroundTimeoutMs: parseTimeoutValue(e.target.value, 15000) })}
                                             className="h-8 text-xs font-mono"
                                             placeholder="15000"
                                         />

--- a/src/components/settings/ProviderSettings.tsx
+++ b/src/components/settings/ProviderSettings.tsx
@@ -583,20 +583,42 @@ const ProviderSettings: React.FC<ProviderSettingsProps> = ({
                                                         </div>
                                                     </div>
                                                     <div className="flex items-center justify-between pt-1 border-t border-gray-100 dark:border-gray-800">
-                                                        <div className="flex flex-col">
-                                                            <Label className="text-2xs font-medium text-gray-700 dark:text-gray-300">Provider Location</Label>
-                                                            <span className="text-[10px] text-gray-500">
-                                                                {cli.isCloud !== false ? 'Cloud / Remote Model' : 'Local / On-Premise Model'}
-                                                            </span>
-                                                        </div>
-                                                        <div className="flex items-center gap-2">
-                                                            <span className="text-xs text-muted-foreground">{cli.isCloud !== false ? 'Cloud' : 'Local'}</span>
-                                                            <Switch
-                                                                checked={cli.isCloud !== false}
-                                                                onCheckedChange={(checked) => onUpdateCustomCli(cli.id, 'isCloud', checked)}
-                                                            />
-                                                        </div>
-                                                    </div>
+                                                         <div className="flex flex-col">
+                                                             <Label htmlFor={`custom-cli-location-${cli.id}`} className="text-2xs font-medium text-gray-700 dark:text-gray-300 cursor-pointer">Provider Location</Label>
+                                                             <span className="text-[10px] text-gray-500">
+                                                                 {cli.isCloud !== false ? 'Cloud / Remote Model' : 'Local / On-Premise Model'}
+                                                             </span>
+                                                         </div>
+                                                         <div className="flex items-center gap-2">
+                                                             <Label htmlFor={`custom-cli-location-${cli.id}`} className="text-xs text-muted-foreground cursor-pointer">{cli.isCloud !== false ? 'Cloud' : 'Local'}</Label>
+                                                             <Switch
+                                                                 id={`custom-cli-location-${cli.id}`}
+                                                                 checked={cli.isCloud !== false}
+                                                                 onCheckedChange={(checked) => {
+                                                                     onUpdateCustomCli(cli.id, 'isCloud', checked);
+                                                                     if (settings.modelRouter) {
+                                                                         const currentLocal = settings.modelRouter.localProvider;
+                                                                         const currentCloud = settings.modelRouter.cloudProvider;
+                                                                         let routerUpdates: any = {};
+                                                                         if (checked && currentLocal === cli.id) {
+                                                                             routerUpdates.localProvider = 'ollama';
+                                                                         } else if (!checked && currentCloud === cli.id) {
+                                                                             routerUpdates.cloudProvider = 'hostedApi';
+                                                                         }
+                                                                         if (Object.keys(routerUpdates).length > 0) {
+                                                                             setSettings(prev => ({
+                                                                                 ...prev,
+                                                                                 modelRouter: {
+                                                                                     ...prev.modelRouter!,
+                                                                                     ...routerUpdates
+                                                                                 }
+                                                                             }));
+                                                                         }
+                                                                     }
+                                                                 }}
+                                                             />
+                                                         </div>
+                                                     </div>
                                                 </CardContent>
                                             </Card>
                                         ))}

--- a/src/components/settings/ProviderSettings.tsx
+++ b/src/components/settings/ProviderSettings.tsx
@@ -514,7 +514,8 @@ const ProviderSettings: React.FC<ProviderSettingsProps> = ({
                                             id: crypto.randomUUID(),
                                             name: 'New Custom CLI',
                                             command: '',
-                                            isConfigured: false
+                                            isConfigured: false,
+                                            isCloud: true
                                         }); 
                                     }}
                                 >
@@ -578,6 +579,21 @@ const ProviderSettings: React.FC<ProviderSettingsProps> = ({
                                                                 }}
                                                                 placeholder="Enter Key"
                                                                 className="h-8 text-xs"
+                                                            />
+                                                        </div>
+                                                    </div>
+                                                    <div className="flex items-center justify-between pt-1 border-t border-gray-100 dark:border-gray-800">
+                                                        <div className="flex flex-col">
+                                                            <Label className="text-2xs font-medium text-gray-700 dark:text-gray-300">Provider Location</Label>
+                                                            <span className="text-[10px] text-gray-500">
+                                                                {cli.isCloud !== false ? 'Cloud / Remote Model' : 'Local / On-Premise Model'}
+                                                            </span>
+                                                        </div>
+                                                        <div className="flex items-center gap-2">
+                                                            <span className="text-xs text-muted-foreground">{cli.isCloud !== false ? 'Cloud' : 'Local'}</span>
+                                                            <Switch
+                                                                checked={cli.isCloud !== false}
+                                                                onCheckedChange={(checked) => onUpdateCustomCli(cli.id, 'isCloud', checked)}
                                                             />
                                                         </div>
                                                     </div>


### PR DESCRIPTION
## Summary

Adds the missing backend implementation for ProductOS model routing via the existing `autoRouter` provider type. ProductOS can now route between a local trained provider, currently Ollama by default, and a cloud/fallback provider using explicit privacy/performance policy.

## Specification

### Provider activation

Set `activeProvider` to `autoRouter`.

```json
{
  "activeProvider": "autoRouter",
  "modelRouter": {
    "enabled": true,
    "mode": "auto",
    "localProvider": "ollama",
    "cloudProvider": "hostedApi",
    "fallback": "cloudRedacted",
    "localTimeoutMs": 3000,
    "backgroundTimeoutMs": 15000,
    "defaultPrivacyLevel": "workspace-private",
    "logDecisions": true
  }
}
```

### Routing modes

- `auto`: prefer local for private/workspace data; public requests can fallback to cloud.
- `privacyFirst`: prefer local even when privacy metadata is missing.
- `performanceFirst`: cloud-first for public requests, local fallback; private data remains local-first.
- `localOnly`: always local, no fallback.
- `cloudOnly`: always cloud, no fallback.

### Fallback modes

- `none`: fail fast, no fallback.
- `cloud`: send original request to cloud.
- `cloudRedacted`: redact obvious secrets/tokens/private-key blocks before cloud fallback.
- `askUser`: fail with approval-required message instead of sending private data to cloud.
- `local`: local fallback for cloud-first routes.

### Latency behavior

- Foreground local attempts are bounded by `localTimeoutMs`, default `3000ms`.
- Background/workflow attempts are bounded by `backgroundTimeoutMs`, default `15000ms`.
- Timeout aborts the local request signal before fallback, so slow local inference does not continue running unnecessarily.

### Routing metadata

Responses include `metadata.routing` with:

- selected provider/model
- primary/fallback providers
- fallback used/request type
- routing reason
- latency
- privacy level and secret-detection flag
- local/cloud classification

## Implementation notes

- Adds `node-backend/lib/model-router.mjs` with deterministic routing policy, cloud-redaction helper, and `RoutedAIProvider`.
- Wires `autoRouter` into `AIService.createProvider` and backend provider support checks.
- Adds typed `ModelRouterConfig` to the frontend API contracts.
- Adds `docs/model-routing.md` with configuration, policy, latency, metadata, and safety notes.
- Adds router unit tests for private routing, explicit provider bypass, performance-first routing, redaction, timeout fallback, and metadata.

## Safety

`cloudRedacted` is a backstop, not a full DLP system. Highly sensitive work should use `localOnly` or `askUser` until stronger classification/redaction exists.

## Verification

- `node --test node-backend/tests/model-router.test.mjs` — 5/5 passing
- `npm run build` — passing
- `npm run test:backend` — 148/148 passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable AI model routing between local and cloud providers.
  * Supports privacy-first and performance-first modes, request redaction, timeouts, and controlled cloud fallback.
  * Responses include routing details for improved transparency.
  * Added settings for providers, fallback behavior, privacy levels, timeouts, and decision logging.
  * Custom providers can be marked as local or cloud-based.
  * Added automatic provider selection with authentication and fallback handling.

* **Documentation**
  * Added guidance for configuring routing policies, provider settings, privacy protections, and safety constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->